### PR TITLE
:sparkles: Add commit template file with emoji prefix

### DIFF
--- a/.commit_template
+++ b/.commit_template
@@ -1,0 +1,27 @@
+
+
+# ==== Emojis ====
+# 🐛  :bug: when fixing a bug
+# ✨  :sparkles: when adding or improving a function
+# 🎉  :tada: when adding or improving an important function 
+# ♻️  :recycle: when refactoring code
+# 🔥  :fire: when removing code or files
+# 💚  :green_heart: when fixing the test or CI build
+# 👕  :shirt: when removing linter warnings
+# 🚀  :rocket: when improving performance
+# 🆙  :up: when upgrading dependencies
+# 🔒  :lock: when dealing with security
+
+# ==== Format ====
+# :emoji: Subject
+#
+# Commit body...
+
+# ==== The Seven Rules ====
+# 1. Separate subject from body with a blank line
+# 2. Limit the subject line to 50 characters
+# 3. Capitalize the subject line
+# 4. Do not end the subject line with a period
+# 5. Use the imperative mood in the subject line
+# 6. Wrap the body at 72 characters
+# 7. Use the body to explain what and why vs. how


### PR DESCRIPTION
In order to support dividing commit according to its goal, emoji prefix for commit message is introduced.
- configure: git config commit.template .commit_template