### PR TITLE
:recycle: Remove archived_at from users

### DIFF
--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -153,7 +153,9 @@ class CourseMembersController < ApplicationController
       user_suggestions = []
       excludes = exclude_members(params[:tmp_managers], params[:course_id])
       users.each do |u|
-        user_suggestions.push(value: u.id, label: u.id_full_name) unless excludes.include?(u.id)
+        # for the case given_name is nil, to_s is added
+        label = u.signin_name + ', ' + u.family_name + ' ' + u.given_name.to_s
+        user_suggestions.push(value: u.id, label: label) unless excludes.include?(u.id)
       end
       user_suggestions.slice!(AUTOCOMPLETE_MAX_SIZE...user_suggestions.size)
       render json: user_suggestions

--- a/app/controllers/signin_controller.rb
+++ b/app/controllers/signin_controller.rb
@@ -15,6 +15,7 @@ class SigninController < ApplicationController
     if user
       if (user.system_staff? && !inside_ip?(SYSTEM_MANAGE_IPS)) || user.role == 'suspended'
         # system administrator can only signin from SYSTEM_MANAGE_IPS
+        # suspended user can not signin
         flash[:message] = t('views.signin.errors.message1')
         render 'layouts/renders/resource', locals: { resource: 'index' }
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -102,17 +102,18 @@ class UsersController < ApplicationController
     end
 
     def ajax_update_user_account
-      if User.system_staff? session[:id]
-        selected_user = User.find(params[:id])
+      user = User.find session[:id]
+      if user.system_staff?
+        selected_user = User.find params[:id]
         original_role = selected_user.role
         if params[:user][:password].nil? || selected_user.authentication == 'ldap'
-          update_result = selected_user.update_attributes(role: params[:user][:role])
-        else
+          update_result = selected_user.update_attributes(role: params[:user][:role]) if User.role_editable? user.role, original_role
+        elsif User.password_editable? user.role, original_role
           update_result = selected_user.update_attributes(user_params)
         end
 
         if update_result
-          flash[:message] = selected_user.full_name + 'さんのアカウントを更新しました。'
+          flash[:message] = selected_user.full_name + 'のアカウントを更新しました。'
           flash[:message_category] = 'info'
         else
           flash[:message] = '入力した情報に誤りがあります。'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -538,7 +538,7 @@ module ApplicationHelper
     else
       card['icon'] = 'fa fa-user'
     end
-    card['header'] = link_to_if(user.web_url?, user.full_name + ' [' + user.phonetic_full_name + ']', user.web_url, target: '_blank')
+    card['header'] = link_to_if(user.web_url?, user.full_name_all, user.web_url, target: '_blank')
     card['body'] = user.description
     card['summary'] = false
     if user.updated_at

--- a/app/views/course_members/_members.html.erb
+++ b/app/views/course_members/_members.html.erb
@@ -9,7 +9,7 @@
           <%= render partial: "layouts/image", locals: {obj: user, fa_class: 'fa-user', size: 'm'} %>
         </td>
         <td class="name-td">
-          <%= link_to user.full_name + " / " + user.phonetic_full_name, {controller: 'course_members', action: 'ajax_show', id: user.id}, remote: true %>
+          <%= link_to user.full_name_all, {controller: 'course_members', action: 'ajax_show', id: user.id}, remote: true %>
         </td>
       </tr>
       <% end %>

--- a/app/views/layouts/_member_candidates.html.erb
+++ b/app/views/layouts/_member_candidates.html.erb
@@ -11,7 +11,7 @@
           <%= render partial: 'layouts/image', locals: {obj: user[0], fa_class: 'fa-user', size: 'm'} %>
         </td>
         <td class="name-td">
-          <%= user[0].full_name + ' / ' + user[0].phonetic_full_name %>
+          <%= user[0].full_name_all %>
           <span class="badge badge-secondary"><%= member_role_text category, user[1] %></span>
         </td>
         <td class="button-td">

--- a/app/views/users/_account_pref.html.erb
+++ b/app/views/users/_account_pref.html.erb
@@ -19,10 +19,9 @@
 					</div>
 
 					<div class="form-group row">
-						<%= f.label :password_confirmation, 'パスワードの確認', class: "col-md-3 col-form-label text-sm-right" %>
+						<%= f.label :password_confirmation, 'パスワードの再入力', class: "col-md-3 col-form-label text-sm-right" %>
 						<div class="col-md-7">
 							<%= f.password_field :password_confirmation, class: "form-control" %>
-							<div class="form-text">同じパスワードを再入力</div>
 						</div>
 					</div>
 

--- a/app/views/users/_update_user.html.erb
+++ b/app/views/users/_update_user.html.erb
@@ -1,74 +1,90 @@
 <% if @selected_user %>
 <div class="bordered-block">
-  <h2>3. アカウントの設定：<%= @selected_user.full_name %>さん</h2>
+  <h2>3. アカウントの設定：<%= @selected_user.full_name %></h2>
   <%= form_for @selected_user, url: {action: :ajax_update_user_account, id: @selected_user.id, search_word: @search_word}, html: {id: 'user_form', class: "form-horizontal", name: 'user_form', multipart: true}, remote: true do |f| %>
   <%#= f.error_messages %>
+
+  <div class="form-group row">
+    <label class="col-md-3 col-form-label"><%= t('views.preferences.account') %><%= t('activerecord.others.created_at') %></label>
+    <div class="col-md-7"><%= format_time @selected_user.created_at, "ymdhm" %></div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-md-3 col-form-label"><%= t('views.preferences.account') %><%= t('activerecord.others.updated_at') %></label>
+    <div class="col-md-7"><%= format_time @selected_user.updated_at, "ymdhm" %></div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-md-3 col-form-label"><%= t('activerecord.attributes.user.last_signin_at') %></label>
+    <div class="col-md-7"><%= last_signin_at_text(@selected_user.last_signin_at) %></div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-md-3 col-form-label"><%= t('activerecord.attributes.user.authentication') %></label>
+    <div class="col-md-7"><%= t('activerecord.others.user.authentication.' + @selected_user.authentication) %></div>
+  </div>
+
+  <% password_editable = User.password_editable? @user.role, @selected_user.role %>
+  <div class="form-group row">
+    <%= f.label :password, 'パスワード', class: "col-md-3 col-form-label" %>
+    <div class="col-md-7">
+      <% if password_editable %>
+      <%= f.password_field :password, class: "form-control" %>
+      <ul class="form-list">
+        <li><span style="font-weight: bold;">英数字<%= USER_PASSWORD_MIN_LENGTH %>〜<%= USER_PASSWORD_MAX_LENGTH %>文字</span>で設定</li>
+        <li><%= t('views.system_messages.preferences.no_password_edit') %></li>
+        <li><%= t('views.system_messages.preferences.self_password_edit') %></li>
+      </ul>
+      <% else %>
+      <div> ***** </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="form-group row">
+    <%= f.label :password_confirmation, 'パスワードの再入力', class: "col-md-3 col-form-label" %>
+    <div class="col-md-7">
+      <% if password_editable %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+      <% else %>
+      <div> ***** </div>
+      <% end %>
+    </div>
+  </div>
 
   <div class="form-group row">
     <label class="col-md-3 col-form-label">学習コース</label>
     <div class="col-md-7">
       <% courses = Course.associated_by @selected_user.id, "learner" %>
+      <% if courses.size.zero? %>
+      <%= t('views.none') %>
+      <% else %>
       <% courses.each do |course| %>
       <%= course.title %>&nbsp;
       <% end %>
+      <% end %>
     </div>
   </div>
-  <div class="form-group row">
-    <label class="col-md-3 col-form-label"><%= t('activerecord.attributes.user.last_signin_at') %></label>
-    <div class="col-md-7"><%= last_signin_at_text(@selected_user.last_signin_at) %></div>
-  </div>
-  <div class="form-group row">
-    <label class="col-md-3 col-form-label">アカウント作成</label>
-    <div class="col-md-7"><%= format_time @selected_user.created_at, "ymdhm" %></div>
-  </div>
-  <div class="form-group row">
-    <label class="col-md-3 col-form-label"><%= t('activerecord.attributes.user.authentication') %></label>
-    <div class="col-md-7"><%= t('activerecord.others.user.authentication.' + @selected_user.authentication) %></div>
-  </div>
+
   <div class="form-group row">
     <label class="col-md-3 col-form-label"><%= t('views.content.manage') %></label>
     <div class="col-md-7"><%= @selected_user.content_manageable? ? t('views.possible') : t('views.impossible') %></div>
   </div>
 
-  <% editable = ((@user.role == 'manager') && (@selected_user.role == 'user')) || (@user.role == 'admin') %>
-  <div class="form-group row">
-    <%= f.label :password, 'パスワード', class: "col-md-3 col-form-label" %>
-    <div class="col-md-7">
-      <% if editable %>
-      <%= f.password_field :password, class: "form-control" %>
-      <ul class="form-list">
-        <li><span style="font-weight: bold;">英数字<%= USER_PASSWORD_MIN_LENGTH %>〜<%= USER_PASSWORD_MAX_LENGTH %>文字</span>で設定</li>
-        <li>変更しない場合は空欄</li>
-      </ul>
-      <% else %>
-      <div> *** </div>
-      <% end %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= f.label :password_confirmation, 'パスワードの確認', class: "col-md-3 col-form-label" %>
-    <div class="col-md-7">
-      <% if editable %>
-      <%= f.password_field :password_confirmation, class: "form-control" %>
-      <div class="form-text">同じパスワードを再入力</div>
-      <% else %>
-      <div> *** </div>
-      <% end %>
-    </div>
-  </div>
-
+  <% role_editable = User.role_editable? @user.role, @selected_user.role %>
   <div class="form-group row">
     <%= f.label :password_confirmation, 'アカウント種別', class: "col-md-3 col-form-label" %>
     <div class="col-md-7">
-      <% if (((@user.role == 'admin') || (@user.role == 'manager')) && (@selected_user.role != 'admin')) %>
-      <%= f.select :role, [[t('activerecord.others.user.role.manager'), 'manager'], [t('activerecord.others.user.role.user'), 'user'], [t('activerecord.others.user.role.suspended'), 'suspended']], {}, {class: "form-control"} %>
+      <% if role_editable %>
+      <% role_candidates = [[t('activerecord.others.user.role.user'), 'user'], [t('activerecord.others.user.role.suspended'), 'suspended']] %>
+      <% role_candidates.unshift [t('activerecord.others.user.role.manager'), 'manager'] if @user.role == 'admin' %>
+      <%= f.select :role, role_candidates, {}, {class: "form-control"} %>
       <% else %>
       <span><%= t("activerecord.others.user.role.#{@selected_user.role}") %></span>
       <% end %>
     </div>
   </div>
 
-  <% if editable %>
+  <% if password_editable || role_editable %>
   <div class="control-group">
     <%= link_to raw("<i class='fa fa-times-circle fa-lg'></i> #{t('views.cancel')}"), {action: 'ajax_search_accounts', search_word: @search_word, role: @role}, {id: 'cancel-btn', class: 'btn btn-light', style: 'color:#000; text-decoration: none;', title: 'cancel', remote: true} %>
     <button type="submit" class="btn btn-primary" style="margin-left: 10px;">

--- a/app/views/users/_user_candidates.html.erb
+++ b/app/views/users/_user_candidates.html.erb
@@ -8,7 +8,7 @@
           <%= render partial: "layouts/image", locals: {obj: user, fa_class: 'fa-user', size: 'm'} %>
         </td>
         <td class="name-td">
-          <%= user.full_name + ' / ' + user.phonetic_full_name %>
+          <%= user.full_name_all %>
           <span class="badge badge-secondary"><%= member_role_text 'system', user.role %></span>
         </td>
         <td class="button-td">

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -54,13 +54,10 @@ OUTCOME_MAX_FILE_SIZE = 10
 OUTCOME_MAX_SIZE = 9
 
 # max number of user search results for system administrator
-USER_SEARCH_MAX_SIZE = 100
+USER_SEARCH_MAX_SIZE = 50
 
 # max peer review number per learner
 STORY_PEER_REVIEW_MAX_SIZE = 9
-
-# autocomplete category: signin_name / full_name / phonetic_full_name
-AUTOCOMPLETE_CATEGORY = 'phonetic_full_name'.freeze
 
 # time delay for autocomplete
 AUTOCOMPLETE_DELAY = 100
@@ -70,6 +67,9 @@ AUTOCOMPLETE_MAX_SIZE = 20
 
 # min character length for autocomplete
 AUTOCOMPLETE_MIN_LENGTH = 1
+
+# autocomplete name category: signin / signin_full / signin_full_phonetic
+AUTOCOMPLETE_NAME_CATEGORY = 'signin_full_phonetic'.freeze
 
 # FIXME: PushNotification
 # FCM_AUTHORIZATION_KEY = ''

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -277,7 +277,6 @@ en:
         title: Title
 
       user:
-        archived_at: Archived at
         attendances: Attendances
         authentication: Authentication
         contents: Contents
@@ -320,6 +319,8 @@ en:
           manager: Manager
           assistant: Assistant
           user: User
+      created_at: created at
+      updated_at: updated at
       user:
         authentication:
           local: Local
@@ -479,6 +480,9 @@ en:
       no_note_resources: Currently no notes managed
       no_snippets: Currently no snippets
       no_search_results: No Search Results
+      preferences:
+        self_password_edit: Self account password can be edit from Settings> Account
+        no_password_edit: Leave blank for no password change
     system_version: System Version
     units:
       characters: characters

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -277,7 +277,6 @@ ja:
         title: タイトル
 
       user:
-        archived_at: アーカイブ日時：
         attendances: 出席者
         authentication: 認証方式
         contents: 内容
@@ -295,7 +294,7 @@ ja:
         image_file_name: 画像ファイル名
         image_file_size: 画像ファイルのサイズ
         image_updated_at: 画像ファイルの更新日時
-        last_signin_at: 最後のサインイン日時
+        last_signin_at: 最終サインイン日時
         lessons: :activerecord.models.lesson
         notes: :activerecord.models.note
         outcome_messages: :activerecord.models.outcome_message
@@ -320,6 +319,8 @@ ja:
           manager: 管理者
           assistant: アシスタント
           user: 利用者
+      created_at: 作成日時
+      updated_at: 更新日時
       user:
         authentication:
           local: ローカル
@@ -479,6 +480,9 @@ ja:
       no_note_resources: 現在、管理しているノートはありません
       no_snippets: 現在、ノートに未保存のWebから収集した情報はありません
       no_search_results: 検索条件を満たす結果はありません
+      preferences:
+        self_password_edit: 自分のパスワードは、設定 > アカウントから変更
+        no_password_edit: 変更しない場合は空欄
     system_version: システムのバージョン
     units:
       characters: 字

--- a/db/migrate/20170830023212_remove_column_archived_at_from_users.rb
+++ b/db/migrate/20170830023212_remove_column_archived_at_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveColumnArchivedAtFromUsers < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :archived_at, :datetime
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -22,7 +22,6 @@
 #  description          :text
 #  default_note_id      :integer          default(0)
 #  last_signin_at       :datetime
-#  archived_at          :datetime
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,7 +22,6 @@
 #  description          :text
 #  default_note_id      :integer          default(0)
 #  last_signin_at       :datetime
-#  archived_at          :datetime
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #


### PR DESCRIPTION
- Remove users.archived_at from users
  - Suspended date for the user can be seen from users.updated_at
- Add some user name methods (ex. full_namme, short_name) mainly for view
  - To easily adapt the different notation for user name
- Rename AUTOCOMPLETE_CATEGORY constant to AUTOCOMPLETE_NAME_CATEGORY
  - To make clarify that the constant is for user name autocomplete