### PR TITLE
:sparkles: Add course setting menu for system staff at preference　#50

### DIFF
--- a/app/assets/stylesheets/resources/courses.scss
+++ b/app/assets/stylesheets/resources/courses.scss
@@ -4,6 +4,7 @@
 
 @import 'components/color';
 @import 'components/versatile_cards';
+@import 'components/image';
 
 #resource #course-resource {
   @include goal-card;
@@ -18,5 +19,20 @@
   div#self-eval-chart {
     height: 200px;
     width: 602px;
+  }
+  .course-table {
+    .image-td {
+      @include image-40px;
+      text-align: center;
+      width: 80px;
+    }
+    .name-td {
+      font-size: 1.1rem;
+      vertical-align: middle;
+    }
+    .button-td {
+      padding-right: 1rem;
+      text-align: right;
+    }
   }
 }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -273,7 +273,6 @@ class CoursesController < ApplicationController
   def ajax_course_pref
     # for security reason
     if User.system_staff? session[:id]
-      @user = User.find session[:id]
       render 'layouts/renders/main_pane', locals: { resource: 'course_pref' }
     else
       head :ok
@@ -288,7 +287,7 @@ class CoursesController < ApplicationController
     render 'layouts/renders/main_pane_candidates', locals: { resource: 'select_course' }
   end
 
-  def ajax_index_by_manager
+  def ajax_index_by_system_staff
     course = Course.find_by(id: params[:id])
     if course.nil? || (!User.system_staff? session[:id])
       ajax_index_no_course

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -167,7 +167,12 @@ module ApplicationHelper
   def preference_icon(controller_name, action_name)
     case controller_name
     when 'courses'
-      'fa-flag'
+      case action_name
+      when 'ajax_new'
+        'fa-flag'
+      when 'ajax_course_pref'
+        ['fa-flag-o', 'fa-pencil']
+      end
     when 'devices'
       # FIXME: PushNotification
       'fa-mobile'
@@ -655,4 +660,9 @@ module ApplicationHelper
     stared = user_stared_note? user_id, note
     stared ? 'stared' : ''
   end
+
+  def select_options_unspecified(options)
+    options.unshift([t('views.unspecified'), nil])
+  end
+
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -45,4 +45,16 @@ module CoursesHelper
     # messages in the assignment page are limited for learner and managers
     message_manager_id == outcome_manager_id ? 'left' : 'right'
   end
+
+  def status_select_options
+    [[t('activerecord.attributes.course.status_draft'),'draft'], [t('activerecord.attributes.course.status_open'),'open'],[t('activerecord.attributes.course.status_archived'),'archive']]
+  end
+
+  def course_managers_display_list(course)
+    managers = []
+    course.managers.each do |manager|
+      managers.push(manager.full_name)
+    end
+    managers.join(',')
+  end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -47,7 +47,7 @@ module CoursesHelper
   end
 
   def status_select_options
-    [[t('activerecord.attributes.course.status_draft'),'draft'], [t('activerecord.attributes.course.status_open'),'open'],[t('activerecord.attributes.course.status_archived'),'archive']]
+    [[t('activerecord.others.course.status_draft'), 'draft'], [t('activerecord.others.course.status_open'), 'open'], [t('activerecord.others.course.status_archived'), 'archive']]
   end
 
   def course_managers_display_list(course)

--- a/app/helpers/preferences_helper.rb
+++ b/app/helpers/preferences_helper.rb
@@ -6,7 +6,12 @@ module PreferencesHelper
   def preference_title(controller_name, action_name)
     case controller_name
     when 'courses'
-      t('views.preferences.new_course') + ' : ' + t('views.preferences.new_course_summary')
+      case action_name
+      when 'ajax_new'
+        t('views.preferences.new_course') + ' : ' + t('views.preferences.new_course_summary')
+      when 'ajax_course_pref'
+        t('views.preferences.edit_course') + ' : ' + t('views.preferences.edit_course_summary')
+      end
     when 'devices'
       # FIXME: PushNotification
       t('views.preferences.device') + ' : ' + t('views.preferences.device_summary')
@@ -35,7 +40,12 @@ module PreferencesHelper
   def preference_title_id(controller_name, action_name)
     case controller_name
     when 'courses'
-      'new-course-pref'
+      case action_name
+      when 'ajax_new'
+        'new-course-pref'
+      when 'ajax_course_pref'
+        'edit-course-pref'
+      end
     when 'devices'
       # FIXME: PushNotification
       'device-pref'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -265,9 +265,34 @@ class Course < ApplicationRecord
     end
   end
 
+  def self.search(term_id, status, title_parts, manager_parts)
+    @candidates = Course.all.limit(COURSE_SEARCH_MAX_SIZE)
+    @candidates = @candidates.where(term_id: term_id) unless term_id.empty?
+    @candidates = @candidates.where(status: status) unless status.empty?
+    @candidates = @candidates.where('title like ?', '%' + title_parts + '%') if title_parts.present?
+    if manager_parts.present?
+      manager_parts = manager_parts.tr('　',' ')
+      search_words = manager_parts.split(' ');
+      case search_words.length
+      when 2
+        family_name = search_words[0]
+        given_name = search_words[1]
+        logical_operation = 'and'
+      else
+        family_name = given_name = manager_parts
+        logical_operation = 'or'
+      end
+      manager_ids = User.where('family_name like ? ' + logical_operation + ' given_name like ? ', '%' + family_name + '%', '%' + given_name + '%').pluck(:id)
+      course_ids = CourseMember.where(role: 'manager').where('user_id IN (?)', manager_ids).pluck(:course_id).uniq
+      @candidates = @candidates.where('id IN(?)', course_ids)
+    end
+    @candidates
+  end
+
   # ====================================================================
   # Private Functions
   # ====================================================================
+
   private
 
   def set_default_value

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,7 +247,7 @@ class User < ApplicationRecord
   end
 
   def system_preferences
-    system_staff? ? [%w[preferences ajax_new_user_pref], %w[preferences ajax_user_account_pref], %w[courses ajax_new], %w[preferences ajax_notice_pref], %w[terms ajax_new]] : []
+    system_staff? ? [%w[preferences ajax_new_user_pref], %w[preferences ajax_user_account_pref], %w[courses ajax_new], %w[courses ajax_course_pref], %w[preferences ajax_notice_pref], %w[terms ajax_new]] : []
   end
 
   # ====================================================================

--- a/app/views/courses/_course_candidates.html.erb
+++ b/app/views/courses/_course_candidates.html.erb
@@ -15,14 +15,14 @@
           <%= course.title  %> 
         </td>
         <td class="name-td">
-           <a href="#" class="Label label-info" data-toggle="tooltip" data-original-title="<%= managers %>">
-            <%= managers.truncate(COURSE_MANAGER_DISPLAY_MAX_LENGTH) %></a>
+          <span class="badge badge-secondary"><%= t('activerecord.others.course.status_'+course.status) %></span>
         </td>
         <td class="name-td">
-          <span class="badge badge-secondary"><%= t('activerecord.attributes.course.status_'+course.status) %></span>
+           <span class="Label label-info" data-toggle="tooltip" data-original-title="<%= managers %>">
+            <%= managers.truncate(COURSE_MANAGER_DISPLAY_MAX_LENGTH) %></span>
         </td>
         <td class="button-td">
-          <%= link_to({action: "ajax_index_by_manager", id: course.id}, remote: true) do %>
+          <%= link_to({action: "ajax_index_by_system_staff", id: course.id}, remote: true) do %>
           <button type="button" class="btn btn-primary">
             設定
           </button>

--- a/app/views/courses/_course_candidates.html.erb
+++ b/app/views/courses/_course_candidates.html.erb
@@ -1,0 +1,40 @@
+<div class="card block">
+  <h2 class="card-header"><%= title %></h2>
+  <div class="card-body" style="padding: 1px;">
+    <table class="table table-sm table-striped course-table">
+      <% courses.each do |course| %>
+      <tr>
+        <td class="image-td">
+          <%= render partial: "layouts/image", locals: {obj: course, fa_class: 'fa-flag', size: 'm'} %>
+        </td>
+        <td class="name-td">
+          <%= course.term.title %>
+        </td>
+        <% managers = course_managers_display_list(course) %>
+        <td class="name-td">
+          <%= course.title  %> 
+        </td>
+        <td class="name-td">
+           <a href="#" class="Label label-info" data-toggle="tooltip" data-original-title="<%= managers %>">
+            <%= managers.truncate(COURSE_MANAGER_DISPLAY_MAX_LENGTH) %></a>
+        </td>
+        <td class="name-td">
+          <span class="badge badge-secondary"><%= t('activerecord.attributes.course.status_'+course.status) %></span>
+        </td>
+        <td class="button-td">
+          <%= link_to({action: "ajax_index_by_manager", id: course.id}, remote: true) do %>
+          <button type="button" class="btn btn-primary">
+            設定
+          </button>
+          <% end %>
+        </td>
+      </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+<script>
+$(function() {
+  $('[data-toggle="tooltip"]').tooltip( { trigger: "hover"})
+})
+</script>

--- a/app/views/courses/_course_pref.html.erb
+++ b/app/views/courses/_course_pref.html.erb
@@ -1,0 +1,13 @@
+<div id="course-resource" class="scroll-pane">
+  <div class="row">
+    <div class="col-md-12">
+      <h1><%= t('.course_preferences') %></h1>
+      <%= render partial: "layouts/system_message", locals: {message: flash[:message], message_category: flash[:message_category]} %>
+      <div class="block">
+        <%= render(partial: "search_courses") %>
+        <%= render(partial: "select_course") %>
+      </div>
+      <%= render partial: 'layouts/complete_btn', locals: {controller_name: 'preferences', nav_section: "home"} %>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/_search_courses.html.erb
+++ b/app/views/courses/_search_courses.html.erb
@@ -1,0 +1,40 @@
+<div class="bordered-block">
+	<h2>1. <%= t('.search_course') %>
+		<div class="header-explanation"><%= t('.exp_search_course', num: COURSE_SEARCH_MAX_SIZE) %></div>
+	</h2>
+	<div style="margin:2px">
+		<%= form_tag({action: 'ajax_search_courses'}, class: 'form-group', remote: true) do %>
+		<div class="form-group">
+			<div class="form-group form-inline">
+				<div class="form-group col-md-5">
+			<%# --- term --- %>
+			<%= label :term_id, t('activerecord.models.term') + ':' , class: 'col-md-3 col-form-label text-sm-right' %>
+			<%= select_tag :term_id, options_for_select(select_options_unspecified(Term.selectables("all"))), class: 'form-control input-lg' %>
+				</div>
+				<div class="form-group col-md-7">
+			<%# --- title --- %>
+			<%= label :title, t('activerecord.attributes.course.title') + ':' , class: 'col-md-3 col-form-label text-sm-right' %>
+			<%= text_field_tag :title, @search_word, class: 'form-control input-lg', placeholder: t('.placeholder_title') %>
+				</div>
+			</div>
+			<div class="form-group form-inline">
+				<div class="form-group col-md-5">
+			<%# --- status --- %>
+			<%= label :status, t('activerecord.attributes.course.status') + ':' , class: 'col-md-3 col-form-label text-sm-right' %>
+			<%= select_tag :status, options_for_select(select_options_unspecified(status_select_options)), class: 'form-control input-lg' %>
+				</div>
+				<div class="form-group col-md-7">
+			<%# --- manager --- %>
+			<%= label :manager, t('activerecord.attributes.course.managers') + ':', class: 'col-md-3 col-form-label text-sm-right'  %>
+			<%= text_field_tag :manager, @search_word, class: 'form-control input-lg', placeholder:  t('.placeholder_manager') %>
+				</div>
+			</div>
+			<div class="form-group  col-md-11 text-right">
+				<button type="submit" class="btn btn-light center-block" style="margin-left: 8px;">
+					<i class="fa fa-search fa-lg"></i>  <%= t('views.search') %>
+				</button>
+			</div>
+		</div>
+		<% end %>
+	</div>
+</div>

--- a/app/views/courses/_search_courses.html.erb
+++ b/app/views/courses/_search_courses.html.erb
@@ -8,25 +8,25 @@
 			<div class="form-group form-inline">
 				<div class="form-group col-md-5">
 			<%# --- term --- %>
-			<%= label :term_id, t('activerecord.models.term') + ':' , class: 'col-md-3 col-form-label text-sm-right' %>
-			<%= select_tag :term_id, options_for_select(select_options_unspecified(Term.selectables("all"))), class: 'form-control input-lg' %>
+			<%= label :term_id, t('activerecord.models.term') + ':' , class: 'col-md-4 col-form-label text-sm-right' %>
+			<%= select_tag :term_id, options_for_select(select_options_unspecified(Term.selectables("all"))), class: 'form-control input-lg col-md-8' %>
 				</div>
 				<div class="form-group col-md-7">
 			<%# --- title --- %>
-			<%= label :title, t('activerecord.attributes.course.title') + ':' , class: 'col-md-3 col-form-label text-sm-right' %>
-			<%= text_field_tag :title, @search_word, class: 'form-control input-lg', placeholder: t('.placeholder_title') %>
+			<%= label :title, t('activerecord.attributes.course.title') + ':' , class: 'col-md-4 col-form-label text-sm-right' %>
+			<%= text_field_tag :title, @search_word, class: 'form-control input-lg col-md-7', placeholder: t('.placeholder_title') %>
 				</div>
 			</div>
 			<div class="form-group form-inline">
 				<div class="form-group col-md-5">
 			<%# --- status --- %>
-			<%= label :status, t('activerecord.attributes.course.status') + ':' , class: 'col-md-3 col-form-label text-sm-right' %>
-			<%= select_tag :status, options_for_select(select_options_unspecified(status_select_options)), class: 'form-control input-lg' %>
+			<%= label :status, t('activerecord.attributes.course.status') + ':' , class: 'col-md-4 col-form-label text-sm-right' %>
+			<%= select_tag :status, options_for_select(select_options_unspecified(status_select_options)), class: 'form-control input-lg col-md-8' %>
 				</div>
 				<div class="form-group col-md-7">
 			<%# --- manager --- %>
-			<%= label :manager, t('activerecord.attributes.course.managers') + ':', class: 'col-md-3 col-form-label text-sm-right'  %>
-			<%= text_field_tag :manager, @search_word, class: 'form-control input-lg', placeholder:  t('.placeholder_manager') %>
+			<%= label :manager, t('activerecord.attributes.course.managers') + ':', class: 'col-md-4 col-form-label text-sm-right'  %>
+			<%= text_field_tag :manager, @search_word, class: 'form-control input-lg col-md-7', placeholder:  t('.placeholder_manager') %>
 				</div>
 			</div>
 			<div class="form-group  col-md-11 text-right">

--- a/app/views/courses/_select_course.html.erb
+++ b/app/views/courses/_select_course.html.erb
@@ -1,0 +1,9 @@
+<div id="candidates">
+	<%= render partial: "layouts/system_message", locals: {message: flash[:message], message_category: flash[:message_category]} %>
+	<% if @candidates %>
+	<div class="bordered-block clearfix">
+		<h2>2. <%= t('.select_course') %></h2>
+		<%= render(partial: 'course_candidates', locals: {title: t('.current_course'), courses: @candidates}) %>
+	</div>
+	<% end %>
+</div>

--- a/app/views/courses/_toolbar.html.erb
+++ b/app/views/courses/_toolbar.html.erb
@@ -5,7 +5,7 @@
   <%= render partial: "layouts/breadcrumb", locals: {crumbs: [[t("views.navs.top")]]} %>
 <% end %>
 </nav>
-<% case action_name when "ajax_index", "ajax_destroy", "ajax_update", "ajax_index_by_manager" %>
+<% case action_name when "ajax_index", "ajax_destroy", "ajax_update", "ajax_index_by_system_staff" %>
 <% if (@course.staff? session[:id]) || (User.system_staff? session[:id]) %>
 <div id="toolbar-btns">
   <div class="btn-group">

--- a/app/views/courses/_toolbar.html.erb
+++ b/app/views/courses/_toolbar.html.erb
@@ -1,7 +1,11 @@
 <nav id="sub-nav">
+<% case action_name when "ajax_course_pref" %>
+  <%= render partial: 'layouts/breadcrumb', locals: {crumbs: [[t('views.navs.top'), {controller: 'preferences', action: 'ajax_index', nav_section: session[:nav_section]}], [t('courses.course_pref.course_preferences') ]]} %>
+<% else %>
   <%= render partial: "layouts/breadcrumb", locals: {crumbs: [[t("views.navs.top")]]} %>
+<% end %>
 </nav>
-<% case action_name when "ajax_index", "ajax_destroy", "ajax_update" %>
+<% case action_name when "ajax_index", "ajax_destroy", "ajax_update", "ajax_index_by_manager" %>
 <% if (@course.staff? session[:id]) || (User.system_staff? session[:id]) %>
 <div id="toolbar-btns">
   <div class="btn-group">
@@ -10,7 +14,7 @@
       <%= link_to({action: "ajax_edit_notice"}, {class: "dropdown-item", remote: true}) do %>
       <i class="fa fa-bullhorn"></i> <%= t("activerecord.models.notice") %>
       <% end %>
-      <% if (@course.assistant? session[:id]) || (@course.manager? session[:id]) %>
+      <% if (@course.assistant? session[:id]) || (@course.manager? session[:id]) ||  (User.system_staff? session[:id]) %>
       <%= link_to({action: "ajax_edit", id: @course.id}, {class: "dropdown-item", remote: true}) do %>
       <i class="fa fa-pencil"></i> <%= t("views.edit") %>
       <% end %>

--- a/app/views/layouts/renders/main_pane_candidates.js.erb
+++ b/app/views/layouts/renders/main_pane_candidates.js.erb
@@ -1,0 +1,1 @@
+$('#candidates').html("<%= j render(partial: resource) %>");

--- a/app/views/preferences/_preference.html.erb
+++ b/app/views/preferences/_preference.html.erb
@@ -5,9 +5,17 @@
       <% preferences.each do |pref| %>
       <tr>
         <td class="image-td">
-          <div class="icon" style="text-align: center;">
-            <i class="fa <%= preference_icon pref[0], pref[1] %>"></i>
-          </div>
+          <% icon_class = preference_icon pref[0], pref[1]  %>
+          <% if icon_class.class.equal?(Array) %>
+           <div class="icon fa-stack" style="text-align: center;">
+            <i class="fa <%= icon_class[0] %> fa-stack-1x" style="margin-left: -2px;"></i>
+            <i class="fa <%= icon_class[1] %> fa-stack-2x" style="font-size:1.5em; margin-top: 6px; margin-left: 6px"></i>
+           </div>
+          <% else %>
+           <div class="icon" style="text-align: center;">
+            <i class="fa <%= icon_class %>"></i>
+           </div>
+          <% end %>
         </td>
         <td class="name-td">
           <%= link_to preference_title(pref[0], pref[1]), {controller: pref[0], action: pref[1]}, {id: preference_title_id(pref[0], pref[1]), remote: true} %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -71,5 +71,11 @@ AUTOCOMPLETE_MIN_LENGTH = 1
 # autocomplete name category: signin / signin_full / signin_full_phonetic
 AUTOCOMPLETE_NAME_CATEGORY = 'signin_full_phonetic'.freeze
 
+# max number of course search results for system administrator
+COURSE_SEARCH_MAX_SIZE = 50
+
+# max length of course manager display
+COURSE_MANAGER_DISPLAY_MAX_LENGTH = 16
+
 # FIXME: PushNotification
 # FCM_AUTHORIZATION_KEY = ''

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -99,9 +99,6 @@ en:
         overview: Overview
         staff_course_notes: Staff course notes
         status: Status
-        status_archived: Archived
-        status_draft: Draft
-        status_open: Open
         term: :activerecord.models.term
         title: Title
 
@@ -322,6 +319,10 @@ en:
           manager: Manager
           assistant: Assistant
           user: User
+      course:
+        status_archived: Archived
+        status_draft: Draft
+        status_open: Open
       created_at: created at
       updated_at: updated at
       user:

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -99,6 +99,9 @@ en:
         overview: Overview
         staff_course_notes: Staff course notes
         status: Status
+        status_archived: Archived
+        status_draft: Draft
+        status_open: Open
         term: :activerecord.models.term
         title: Title
 
@@ -331,6 +334,18 @@ en:
           user: User
           suspended: Suspended
 
+  courses:
+    course_pref: # app/views/courses/_course_pref.html.erb
+      course_preferences: Course Preferences
+    search_courses: # app/views/courses/_search_courses.html.erb
+      search_course: Search Course
+      exp_search_course: Search courses with term, title, manager, status up to a maximum of %{num}
+      placeholder_title: Input title
+      placeholder_manager: Input name
+    select_course: #app/views/courses/_select_course.html.erb
+      current_course: Current Course
+      select_course: Select Course
+
   views:
     add: Add
     assignment: Assignment
@@ -399,6 +414,8 @@ en:
       account_summary: password
       device: Push Notification
       device_summary: Devices for Push Notification
+      edit_course: Existing Course
+      edit_course_summary: search and edit for existing course
       link: Link
       link_summary: links shown in sidebar
       new_course: New Course
@@ -475,6 +492,7 @@ en:
         select_open_status: open (ourse members can do learning activities in the course)
       input_id_or_name: Input part of user ID or name, and select user.
       no_contents: No contents to display
+      no_courses_with_criteria: No courses with these criteria.
       no_dashboard_resources: Currently no information on the dashboard
       no_lessons: No lessons to display
       no_messages: No messages
@@ -491,5 +509,6 @@ en:
       pieces: pieces
       points: points
     unregister: UnReg
+    unspecified: Unspecified
     updated_at: Upated at
     user_account: User Account

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -98,9 +98,6 @@ ja:
         overview: 概要
         staff_course_notes: スタッフのコースノート
         status: 状態
-        status_archived: アーカイブ
-        status_draft: 準備中
-        status_open: 公開中
         notes: :activerecord.models.note
         term: :activerecord.models.term
         title: タイトル
@@ -322,6 +319,10 @@ ja:
           manager: 管理者
           assistant: アシスタント
           user: 利用者
+      course:
+        status_archived: アーカイブ
+        status_draft: 準備中
+        status_open: 公開中      
       created_at: 作成日時
       updated_at: 更新日時
       user:

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -98,6 +98,9 @@ ja:
         overview: 概要
         staff_course_notes: スタッフのコースノート
         status: 状態
+        status_archived: アーカイブ
+        status_draft: 準備中
+        status_open: 公開中
         notes: :activerecord.models.note
         term: :activerecord.models.term
         title: タイトル
@@ -331,6 +334,19 @@ ja:
           user: 一般ユーザ
           suspended: 利用停止
 
+  courses:
+    course_pref: # app/views/courses/_course_pref.html.erb
+      course_preferences: コース設定
+    search_courses: # app/views/courses/_search_courses.html.erb
+      select_course: コースの選択
+      search_course: コースの検索
+      exp_search_course: '%{num}コースまでを上限に、学期 / タイトル / 教師 / 状態で検索'
+      placeholder_title: タイトル名を入力
+      placeholder_manager: 氏名を入力
+    select_course: #app/views/courses/_select_course.html.erb
+      current_course: 現在のコース
+      select_course: コースの選択
+
   views:
     add: 追加
     assignment: 課題
@@ -399,6 +415,8 @@ ja:
       account_summary: パスワード
       device: プッシュ通知
       device_summary: プッシュ通知をする機器
+      edit_course: 既存コース
+      edit_course_summary: 既存コースの検索と編集
       link: リンク
       link_summary: サイドバーに表示するリンク
       new_course: 新規コース
@@ -475,6 +493,7 @@ ja:
         select_open_status: 公開中（コースを閲覧/学習活動可）
       input_id_or_name: IDまたは氏名の一部を入力して選択
       no_contents: 表示する教材はありません
+      no_courses_with_criteria: 条件を満たすコースが見つかりません
       no_dashboard_resources: 現在、ダッシュボードに表示する情報はありません
       no_lessons: 表示するレッスンはありません
       no_messages: メッセージはありません
@@ -491,5 +510,6 @@ ja:
       pieces: 個
       points: 点
     unregister: 解除
+    unspecified: 指定なし
     updated_at: 最終更新日
     user_account: ユーザアカウント


### PR DESCRIPTION
I'd like to be received a review of my code .

I have one concern.
- Manager's name in search condition works differently, if two words are inputted or not.
  If two words separated with blank are inputted,  first word is regarded as family name and second word as given name.
 Otherwise, word is regarded as both family name and given name.
 There are two cases in manager's search I think.
 One is to search with full name, and the other is to search with family name or given name.
 Is it misleading?
(ex) 
  "Oita Taro" -> search with "Oita" as family name and "Taro" as given name.
  "Oita"  -> search with "Oita" as family name or given name.
