### PR TITLE
:recycle: Rename original_note to original_ws

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -20,10 +20,10 @@ class NotesController < ApplicationController
   def ajax_import_snippet
     source_snippet = Snippet.find params[:snippet_id] if params[:snippet_id]
     source_note = source_snippet.note if source_snippet
-    source_original_note_id = source_note.original_note_id if source_note.original_note_id
-    if source_original_note_id
+    source_original_ws_id = source_note.original_ws_id if source_note.original_ws_id
+    if source_original_ws_id
       user_id = session[:id]
-      notes = Note.where(manager_id: user_id, category: 'worksheet', original_note_id: source_original_note_id).to_a
+      notes = Note.where(manager_id: user_id, category: 'worksheet', original_ws_id: source_original_ws_id).to_a
       note = notes[0]
       if note
         Snippet.create(manager_id: user_id, note_id: note.id, category: source_snippet.category, description: source_snippet.description, source_type: source_snippet.source_type, source_id: source_snippet.source_id, display_order: note.snippets.size + 1, master_id: source_snippet.id)

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -292,15 +292,15 @@ class SnippetsController < ApplicationController
     { formats: ['js'], layout: false, locals: { duration: duration, tags: tags, token: token } }
   end
 
-  def distribute_worksheet(original_note)
-    copy_snippets = Snippet.where(note_id: original_note.id, source_type: 'direct').order(display_order: :asc)
-    course = Course.find(original_note.course_id)
+  def distribute_worksheet(original_ws)
+    copy_snippets = Snippet.where(note_id: original_ws.id, source_type: 'direct').order(display_order: :asc)
+    course = Course.find(original_ws.course_id)
     course.learners.each do |l|
-      notes = Note.where(manager_id: l.id, status: 'original_note', original_note_id: original_note.id).to_a
+      notes = Note.where(manager_id: l.id, status: 'original_ws', original_ws_id: original_ws.id).to_a
       next unless notes.size.zero?
 
       Snippet.transaction do
-        note = Note.create(manager_id: l.id, course_id: course.id, title: original_note.title, overview: original_note.overview, category: 'worksheet', status: 'original_note', original_note_id: original_note.id)
+        note = Note.create(manager_id: l.id, course_id: course.id, title: original_ws.title, overview: original_ws.overview, category: 'worksheet', status: 'original_ws', original_ws_id: original_ws.id)
         copy_snippets.each_with_index do |cs, i|
           Snippet.create(manager_id: l.id, note_id: note.id, category: cs.category, description: cs.description, source_type: 'direct', display_order: i + 1)
         end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -5,7 +5,7 @@ module NotesHelper
 
   def get_review_num(group_notes)
     group_notes.each do |gn|
-      original = Note.find(gn.original_note_id)
+      original = Note.find(gn.original_ws_id)
       return original.peer_reviews_count if original.status == 'review'
     end
     0

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -140,18 +140,18 @@ class Course < ApplicationRecord
     notes = []
     if course_staff
       original_draft_worksheets.each do |ow|
-        notes += Note.where(course_id: id, category: 'worksheet', original_note_id: ow.id).order(updated_at: :desc).to_a
+        notes += Note.where(course_id: id, category: 'worksheet', original_ws_id: ow.id).order(updated_at: :desc).to_a
       end
     else
       original_draft_worksheets.each do |ow|
-        notes += Note.where(course_id: id, category: 'worksheet', original_note_id: ow.id, manager_id: user_id).order(updated_at: :desc).to_a
+        notes += Note.where(course_id: id, category: 'worksheet', original_ws_id: ow.id, manager_id: user_id).order(updated_at: :desc).to_a
       end
     end
     original_review_worksheets.each do |ow|
-      notes += Note.where(course_id: id, category: 'worksheet', original_note_id: ow.id).order(updated_at: :desc).to_a
+      notes += Note.where(course_id: id, category: 'worksheet', original_ws_id: ow.id).order(updated_at: :desc).to_a
     end
     original_open_worksheets.each do |ow|
-      notes += Note.where(course_id: id, category: 'worksheet', original_note_id: ow.id).order(updated_at: :desc).to_a
+      notes += Note.where(course_id: id, category: 'worksheet', original_ws_id: ow.id).order(updated_at: :desc).to_a
     end
     notes
   end

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -64,7 +64,7 @@ class Snippet < ApplicationRecord
 
     note = self.note
     # can not import from private or original_worksheet note
-    return false if note.original_note_id.zero?
+    return false if note.original_ws_id.zero?
     # can not import by course staff
     return false if !note.course || (note.course.staff? user_id)
     true

--- a/db/migrate/20170930234141_rename_column_original_note_id_in_notes_to_original_ws_id.rb
+++ b/db/migrate/20170930234141_rename_column_original_note_id_in_notes_to_original_ws_id.rb
@@ -1,0 +1,5 @@
+class RenameColumnOriginalNoteIdInNotesToOriginalWsId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :notes, :original_note_id, :original_ws_id
+  end
+end

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -5,7 +5,7 @@
 #  id                 :integer          not null, primary key
 #  manager_id         :integer
 #  course_id          :integer          default(0)
-#  original_note_id   :integer          default(0)
+#  original_ws_id     :integer          default(0)
 #  title              :string
 #  overview           :text
 #  status             :string           default("draft")

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -5,7 +5,7 @@
 #  id                 :integer          not null, primary key
 #  manager_id         :integer
 #  course_id          :integer          default(0)
-#  original_note_id   :integer          default(0)
+#  original_ws_id     :integer          default(0)
 #  title              :string
 #  overview           :text
 #  status             :string           default("draft")
@@ -62,8 +62,8 @@ class NoteTest < ActiveSupport::TestCase
     assert_invalid build(:note, status: nil), :status
   end
 
-  # test for validates_inclusion_of :status, in: %w[draft review open archived original_note], if: "category == 'worksheet'"
-  test 'a worksheet note with status that is not included in [draft review open archived original_note] is invalid' do
+  # test for validates_inclusion_of :status, in: %w[draft review open archived original_ws], if: "category == 'worksheet'"
+  test 'a worksheet note with status that is not included in [draft review open archived original_ws] is invalid' do
     assert_invalid build(:original_draft_worksheet, status: ''), :status
     assert_invalid build(:original_draft_worksheet, status: nil), :status
   end
@@ -78,14 +78,14 @@ class NoteTest < ActiveSupport::TestCase
     assert_invalid build(:original_draft_worksheet, course_id: 0), :course_id
   end
 
-  # test for validates_numericality_of :original_note_id, allow_nil: false, equal_to: 0, if: "category == 'private'"
-  test 'a private note with original_note_id that is not 0 is invalid' do
-    assert_invalid build(:note, original_note_id: 1), :original_note_id
-    assert_invalid build(:note, original_note_id: -1), :original_note_id
+  # test for validates_numericality_of :original_ws_id, allow_nil: false, equal_to: 0, if: "category == 'private'"
+  test 'a private note with original_ws_id that is not 0 is invalid' do
+    assert_invalid build(:note, original_ws_id: 1), :original_ws_id
+    assert_invalid build(:note, original_ws_id: -1), :original_ws_id
   end
 
-  # test for validates_numericality_of :original_note_id, allow_nil: false, greater_than_or_equal_to: 0, if: "category == 'worksheet'"
-  test 'a worksheet note with original_note_id that is less than 0 is invalid' do
-    assert_invalid build(:original_draft_worksheet, original_note_id: -1), :original_note_id
+  # test for validates_numericality_of :original_ws_id, allow_nil: false, greater_than_or_equal_to: 0, if: "category == 'worksheet'"
+  test 'a worksheet note with original_ws_id that is less than 0 is invalid' do
+    assert_invalid build(:original_draft_worksheet, original_ws_id: -1), :original_ws_id
   end
 end


### PR DESCRIPTION
In the meantime, note.original_note_id only works with worksheet category