### PR TITLE
:fire: Remove column master_id from snippets, #67

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -17,27 +17,6 @@ class NotesController < ApplicationController
     render 'layouts/renders/main_pane', locals: { resource: 'index_in_group' }
   end
 
-  def ajax_import_snippet
-    source_snippet = Snippet.find params[:snippet_id] if params[:snippet_id]
-    source_note = source_snippet.note if source_snippet
-    source_original_ws_id = source_note.original_ws_id if source_note.original_ws_id
-    if source_original_ws_id
-      user_id = session[:id]
-      notes = Note.where(manager_id: user_id, category: 'worksheet', original_ws_id: source_original_ws_id).to_a
-      note = notes[0]
-      if note
-        Snippet.create(manager_id: user_id, note_id: note.id, category: source_snippet.category, description: source_snippet.description, source_type: source_snippet.source_type, source_id: source_snippet.source_id, display_order: note.snippets.size + 1, master_id: source_snippet.id)
-        note.align_display_order
-      end
-    end
-
-    get_resources
-    @note = Note.find source_note.id
-    @snippets = @note.snippets
-    get_stickies @note.course_id, @note.id
-    render 'layouts/renders/resource', locals: { resource: 'show' }
-  end
-
   # same action for snippets_controller without @sticky
   def ajax_show
     note_id = params[:id].to_i

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -9,7 +9,6 @@
 #  description   :text
 #  source_type   :string           default("direct")
 #  source_id     :integer
-#  master_id     :integer
 #  display_order :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -50,43 +49,6 @@ class Snippet < ApplicationRecord
 
   def deletable?(user_id)
     (manager_id == user_id)
-  end
-
-  def importable?(user_id)
-    # can not import one's own snippet
-    return false if manager_id == user_id
-    # can not import non web snippet
-    return false if source_type != 'web'
-    # can not import imported snippet
-    return false if master_id
-    # can not import already imported snippet
-    return false if imported? user_id
-
-    note = self.note
-    # can not import from private or original_worksheet note
-    return false if note.original_ws_id.zero?
-    # can not import by course staff
-    return false if !note.course || (note.course.staff? user_id)
-    true
-  end
-
-  def imported?(user_id)
-    !Snippet.where(manager_id: user_id, master_id: id).empty?
-  end
-
-  def imported_snippets
-    return [] unless note_id
-    Snippet.where(master_id: id).order(created_at: :asc).to_a
-  end
-
-  def original_note
-    return unless master_id
-    unless Snippet.find_by(id: master_id).nil?
-      master_snippet = Snippet.find(master_id)
-      return if !master_snippet.note_id || master_snippet.note_id.zero?
-      return master_snippet.note if master_snippet.note
-    end
-    nil
   end
 
   def reference_num

--- a/app/views/snippets/items/_footer.html.erb
+++ b/app/views/snippets/items/_footer.html.erb
@@ -3,25 +3,10 @@
     <div class="d-flex justify-content-between">
       <div>
         <%= link_to(get_short_string(snippet.reference_num + ' ' + display_title(snippet.source), 25), snippet.source.url, {target: '_blank'}) %>
-        <% if snippet.original_note && session[:nav_section] == 'open_courses' && session[:nav_id].to_i == snippet.note.course_id %>
-        ( 取り込み元ノート: <%= link_to(raw("<i class='fa fa-file-text'></i>#{snippet.original_note.manager.short_name}"), {controller: 'notes', action: 'ajax_show_from_others', nav_id: snippet.note.course_id, id: snippet.original_note.id}, {remote: true}) %> )
-        <% end %>
       </div>
-      <%  if snippet.importable? session[:id] %>
-      <%= link_to(raw("<i class='fa fa-plus'></i> MyNote"), {action: 'ajax_import_snippet', snippet_id: snippet.id}, {remote: true, title: '自分のノートに取込み'}) %>
-      <% else %>
-      <%= raw("<span class='badge badge-secondary'>取り込み済み</span>") if snippet.imported? session[:id] %>
-      <% end %>
 
       <% if controller_name == 'snippets' %>
       <a data-toggle="collapse" href="#snippet-<%= snippet.id %>-operations" aria-expanded="false" aria-controls="snippet-<%= snippet.id %>-operations"><i class='fa fa-chevron-circle-down'></i> <%= t('.operations') %></a>
-      <% elsif !snippet.imported_snippets.size.zero? && session[:nav_section] == 'open_courses' && session[:nav_id].to_i == snippet.note.course_id %>
-      <div>
-        取り込んだノート:
-        <% snippet.imported_snippets.each do |rs| %>
-        <%= link_to(raw("<i class='fa fa-file-text'></i>#{rs.manager.short_name}"), {controller: 'notes', action: 'ajax_show_from_others', nav_id: snippet.note.course_id, id: rs.note_id}, {remote: true}) if rs.note_id %>&nbsp;&nbsp;
-        <% end %>
-      </div>
       <% end %>
     </div>
   </div>

--- a/db/migrate/20171001055316_remove_master_id_from_snippets.rb
+++ b/db/migrate/20171001055316_remove_master_id_from_snippets.rb
@@ -1,0 +1,10 @@
+class RemoveMasterIdFromSnippets < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :snippets, :master_id
+  end
+
+  def down
+    add_column :snippets, :master_id, :integer
+    add_index :snippets, :master_id
+  end
+end

--- a/test/factories/snippets.rb
+++ b/test/factories/snippets.rb
@@ -9,7 +9,6 @@
 #  description   :text
 #  source_type   :string           default("direct")
 #  source_id     :integer
-#  master_id     :integer
 #  display_order :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -21,7 +20,6 @@ FactoryGirl.define do
     association :note
     association :source, factory: :web_source
     description 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '
-    sequence(:master_id) { |i| i }
     sequence(:display_order) { |i| i }
 
     factory :header_snippet do

--- a/test/models/snippet_test.rb
+++ b/test/models/snippet_test.rb
@@ -9,7 +9,6 @@
 #  description   :text
 #  source_type   :string           default("direct")
 #  source_id     :integer
-#  master_id     :integer
 #  display_order :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null


### PR DESCRIPTION
By removing learner's ability to quote snippet from other learner's worksheet, master_id is unnecessary.