### PR TITLE
:recycle: Add note_indexes table, #67

### DIFF
--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -7,54 +7,45 @@ class SnippetsController < ApplicationController
   def ajax_index
     set_nav_session params[:nav_section], 'snippets'
     @notes = current_user.notes
-    @snippets = Snippet.with_source_and_without_note_by session[:id]
+    @snippets = Snippet.web_snippets_without_note_by session[:id]
     render 'layouts/renders/all', locals: { resource: 'index' }
   end
 
   def ajax_create
     @notes = current_user.notes
-    @snippet = Snippet.new(snippet_params)
-    @snippet.manager_id = session[:id]
-    @snippet.note_id = params[:note_id].to_i
-    @snippet.category = params[:category]
-    @snippet.source_type = 'direct'
-    @snippet.display_order = params[:display_order].to_i
+    note_id = params[:note_id].to_i
 
-    if @snippet.description != ''
-      unless @snippet.save
-        flash[:message] = '書き込みを保存できませんでした'
-        flash[:message_category] = 'error'
-      end
+    @snippet = Snippet.new(manager_id: session[:id], category: params[:category], description: params[:snippet][:description], source_type: 'direct')
+    Snippet.transaction do
+      @snippet.save!
+      NoteIndex.create!(note_id: note_id, snippet_id: @snippet.id, display_order: params[:display_order].to_i)
     end
-
-    @note = Note.find @snippet.note_id
-    @note.align_display_order
-    @snippets = @note.snippets
-    render 'snippets/renders/snippets'
+    render_snippets note_id
+  rescue StandardError
+    flash[:message] = t('controllers.snippets.snippet_creation_error')
+    flash[:message_category] = 'error'
+    render_snippets note_id
   end
 
   def ajax_upload
     @notes = current_user.notes
-    display_order = params[:display_order].to_i
     note_id = params[:note_id].to_i
 
-    @snippet = Snippet.new(manager_id: session[:id], note_id: note_id, category: 'image', source_type: 'upload', display_order: display_order)
+    @snippet = Snippet.new(manager_id: session[:id], category: 'image', source_type: 'upload')
     Snippet.transaction do
-      if @snippet.save
-        param_hash = snippet_file_params
-        param_hash['snippet_id'] = @snippet.id
-        snippet_file = SnippetFile.new(param_hash)
-        if snippet_file.save
-          @snippet.update_attributes(category: snippet_file.file_type, source_id: snippet_file.id, description: snippet_file.upload.url)
-        else
-          @snippet.destroy
-        end
-      end
+      @snippet.save!
+      NoteIndex.create!(note_id: note_id, snippet_id: @snippet.id, display_order: params[:display_order].to_i)
+      param_hash = snippet_file_params
+      param_hash['snippet_id'] = @snippet.id
+      snippet_file = SnippetFile.new(param_hash)
+      snippet_file.save!
+      @snippet.update_attributes!(category: snippet_file.file_type, source_id: snippet_file.id, description: snippet_file.upload.url)
     end
-    @note = Note.find note_id
-    @note.align_display_order
-    @snippets = @note.snippets
-    render 'snippets/renders/snippets'
+    render_snippets note_id
+  rescue StandardError
+    flash[:message] = t('controllers.snippets.snippet_upload_error')
+    flash[:message_category] = 'error'
+    render_snippets note_id
   end
 
   def ajax_update
@@ -62,36 +53,29 @@ class SnippetsController < ApplicationController
 
     if params[:snippet][:description] == ''
       if snippet.deletable? session[:id]
-        @note = snippet.note
-        @notes = Note.where(manager_id: snippet.manager_id).order(updated_at: :desc)
         snippet.destroy
-        @note.align_display_order
-        @snippets = @note.snippets
-        render 'snippets/renders/snippets'
+        @notes = Note.where(manager_id: session[:id]).order(updated_at: :desc)
+        render_snippets params[:note_id].to_i
       end
     else
       # max character length for user text form is USER_TEXT_LENGTH
       params[:snippet][:description] = params[:snippet][:description][0, USER_TEXT_LENGTH]
       snippet.update_attributes(snippet_params)
-      @note = Note.find snippet.note_id
-      @snippets = @note.snippets
-      render 'snippets/renders/snippet', locals: { snippet: snippet }
+      render_snippet params[:note_id], snippet
     end
   end
 
   def ajax_update_pdf
     snippet = Snippet.find(params[:id])
-    @notes = current_user.notes
 
     snippet.update_attributes(snippet_params)
-    if snippet.note_id
-      # snippet inside of note
-      @note = Note.find snippet.note_id
-      @snippets = @note.snippets
-      render 'snippets/renders/snippet', locals: { snippet: snippet }
+    if params[:note_id]
+      # snippet inside the note
+      render_snippet params[:note_id], snippet
     else
-      # snippet outside of note
-      @snippets = Snippet.with_source_and_without_note_by session[:id]
+      # snippet outside the note
+      @notes = current_user.notes
+      @snippets = Snippet.web_snippets_without_note_by session[:id]
       render 'layouts/renders/resource', locals: { resource: 'index' }
     end
   end
@@ -100,33 +84,26 @@ class SnippetsController < ApplicationController
     snippet = Snippet.find(params[:id])
     snippet_file = snippet.snippet_file
     snippet_file.update_attributes(snippet_file_params)
-    snippet.update_attributes(description: snippet_file.upload.url)
-    @note = Note.find snippet.note_id
-    @snippets = @note.snippets
-    render 'snippets/renders/snippet', locals: { snippet: snippet }
+    snippet.update_attributes(category: snippet_file.file_type, description: snippet_file.upload.url)
+    render_snippet params[:note_id], snippet
   end
 
   def ajax_destroy
     snippet = Snippet.find(params[:id])
-    @notes = current_user.notes
     return unless snippet.deletable? session[:id]
-    note_id = snippet.note_id if snippet.note_id
+    @notes = current_user.notes
+    note_id = params[:note_id].to_i if params[:note_id]
     snippet.destroy
 
     if snippet.source_type == 'web'
       source_id = snippet.source_id
-      same_source_snippets = Snippet.where(source_type: 'web', source_id: source_id)
-      WebSource.find(source_id).destroy if same_source_snippets.size.zero?
+      WebSource.find(source_id).destroy if Snippet.where(source_type: 'web', source_id: source_id).count.zero?
     end
 
     if note_id
-      @note = Note.find note_id
-      @note.align_display_order
-      @snippets = @note.snippets
-      render 'snippets/renders/snippets'
-      # render 'layouts/renders/resource', locals: { resource: 'show' }
+      render_snippets note_id
     else
-      @snippets = Snippet.with_source_and_without_note_by session[:id]
+      @snippets = Snippet.web_snippets_without_note_by session[:id]
       render 'layouts/renders/resource', locals: { resource: 'index' }
     end
   end
@@ -135,9 +112,9 @@ class SnippetsController < ApplicationController
     @note = Note.find params[:note_id]
     if @note.deletable? session[:id]
       @note.destroy
-      @notes = current_user.notes
       current_user.update_attributes(default_note_id: 0) if current_user.default_note_id == params[:note_id].to_i
-      @snippets = Snippet.with_source_and_without_note_by session[:id]
+      @notes = current_user.notes
+      @snippets = Snippet.web_snippets_without_note_by session[:id]
       render 'layouts/renders/all', locals: { resource: 'index' }
     else
       @notes = current_user.notes
@@ -162,31 +139,42 @@ class SnippetsController < ApplicationController
     end
   end
 
-  def ajax_paste
+  def ajax_transfer
     snippet = Snippet.find params[:id] if params[:id]
-    note_id = params[:note_id].to_i if params[:note_id]
-    if !note_id
-      original_note_id = snippet.note_id
-      snippet.update_attributes(note_id: nil, display_order: nil)
-      @note = Note.find original_note_id
-      @note.align_display_order
-      @notes = current_user.notes
-      @snippets = @note.snippets
-      render 'layouts/renders/resource', locals: { resource: 'show' }
-    elsif note_id > 0
-      original_note_id = snippet.note_id
-      note = Note.find note_id
-      snippet.update_attributes(note_id: note_id, display_order: note.snippets.size + 1)
-      @notes = current_user.notes
-      if original_note_id
-        @note = Note.find original_note_id
+    from_note_id = params[:from_note_id].to_i if params[:from_note_id]
+    to_note_id = params[:to_note_id].to_i if params[:to_note_id]
+
+    if snippet.transferable? session[:id], to_note_id
+      if to_note_id
+        display_order = NoteIndex.where(note_id: to_note_id).count + 1
+        @notes = current_user.notes
+        if from_note_id
+          ni = NoteIndex.find_by(note_id: from_note_id, snippet_id: snippet.id)
+          ni.update_attributes(note_id: to_note_id, display_order: display_order)
+          @note = Note.find from_note_id
+          @note.align_display_order
+          @snippets = @note.snippets
+          render 'layouts/renders/resource', locals: { resource: 'show' }
+        else
+          NoteIndex.create(note_id: to_note_id, snippet_id: snippet.id, display_order: display_order)
+          @snippets = Snippet.web_snippets_without_note_by session[:id]
+          render 'layouts/renders/resource', locals: { resource: 'index' }
+        end
+      else
+        ni = NoteIndex.find_by(note_id: from_note_id, snippet_id: snippet.id)
+        ni.destroy
+        @note = Note.find from_note_id
         @note.align_display_order
+        @notes = current_user.notes
         @snippets = @note.snippets
         render 'layouts/renders/resource', locals: { resource: 'show' }
-      else
-        @snippets = Snippet.with_source_and_without_note_by session[:id]
-        render 'layouts/renders/resource', locals: { resource: 'index' }
       end
+    else
+      flash[:message] = t('controllers.snippets.note_transfer_error')
+      flash[:message_category] = 'error'
+      @notes = current_user.notes
+      @snippets = Snippet.web_snippets_without_note_by session[:id]
+      render 'layouts/renders/resource', locals: { resource: 'index' }
     end
   end
 
@@ -200,15 +188,17 @@ class SnippetsController < ApplicationController
 
   def ajax_sort
     @note = Note.find params[:note_id].to_i
-    params[:snippet].each_with_index { |id, i| Snippet.update(id, display_order: i + 1) }
+    params[:snippet].each_with_index do |id, i|
+      ni = NoteIndex.find_by(note_id: @note.id, snippet_id: id)
+      ni.update_attributes(display_order: i + 1) if ni
+    end
     @notes = current_user.notes
     @snippets = @note.snippets
     render 'snippets/renders/snippets'
   end
 
   def ajax_create_note
-    # max character length for overview is 500
-    params[:note][:overview] = params[:note][:overview][0, 500]
+    params[:note][:overview] = params[:note][:overview][0, NOTE_OVERVIEW_MAX_LENGTH]
     @note = Note.new(note_params)
     @note.manager_id = session[:id]
     if @note.save
@@ -222,8 +212,7 @@ class SnippetsController < ApplicationController
   end
 
   def ajax_update_note
-    # max character length for overview is 500
-    params[:note][:overview] = params[:note][:overview][0, 500]
+    params[:note][:overview] = params[:note][:overview][0, NOTE_OVERVIEW_MAX_LENGTH]
     @note = Note.find params[:note_id].to_i
 
     if @note.status_updatable?(params[:note][:status], session[:id]) && @note.update_attributes(note_params)
@@ -293,16 +282,17 @@ class SnippetsController < ApplicationController
   end
 
   def distribute_worksheet(original_ws)
-    copy_snippets = Snippet.where(note_id: original_ws.id, source_type: 'direct').order(display_order: :asc)
+    copy_snippets = original_ws.direct_snippets
     course = Course.find(original_ws.course_id)
     course.learners.each do |l|
       notes = Note.where(manager_id: l.id, status: 'original_ws', original_ws_id: original_ws.id).to_a
       next unless notes.size.zero?
 
       Snippet.transaction do
-        note = Note.create(manager_id: l.id, course_id: course.id, title: original_ws.title, overview: original_ws.overview, category: 'worksheet', status: 'original_ws', original_ws_id: original_ws.id)
+        note = Note.create!(manager_id: l.id, course_id: course.id, title: original_ws.title, overview: original_ws.overview, category: 'worksheet', status: 'original_ws', original_ws_id: original_ws.id)
         copy_snippets.each_with_index do |cs, i|
-          Snippet.create(manager_id: l.id, note_id: note.id, category: cs.category, description: cs.description, source_type: 'direct', display_order: i + 1)
+          snippet = Snippet.create!(manager_id: l.id, category: cs.category, description: cs.description, source_type: 'direct')
+          NoteIndex.create!(note_id: note.id, snippet_id: snippet.id, display_order: i + 1)
         end
       end
     end
@@ -335,13 +325,29 @@ class SnippetsController < ApplicationController
     description
   end
 
+  def render_snippet(note_id, snippet)
+    @note = Note.find note_id
+    @snippets = @note.snippets
+    render 'snippets/renders/snippet', locals: { snippet: snippet }
+  end
+
+  def render_snippets(note_id)
+    @note = Note.find note_id
+    @note.align_display_order
+    @snippets = @note.snippets
+    render 'snippets/renders/snippets'
+  end
+
   def save_web_snippet(url, title, description, category, user)
     source_id = save_web_source url, title
     if (source_id > 0) && ((category == 'text') || (category == 'pdf'))
       note_id = user.default_note_id
       if note_id > 0 && Note.find_by(id: note_id) && Note.find(note_id).manager_id == user.id
         display_order = Note.find(note_id).snippets.size + 1
-        Snippet.create(manager_id: user.id, category: category, description: description, source_type: 'web', source_id: source_id, note_id: note_id, display_order: display_order)
+        Snippet.transaction do
+          snippet = Snippet.create!(manager_id: user.id, category: category, description: description, source_type: 'web', source_id: source_id)
+          NoteIndex.create!(snippet_id: snippet.id, note_id: note_id, display_order: display_order)
+        end
       else
         Snippet.create(manager_id: user.id, category: category, description: description, source_type: 'web', source_id: source_id)
       end
@@ -382,7 +388,10 @@ class SnippetsController < ApplicationController
       note_id = user.default_note_id
       if note_id > 0 && Note.find_by(id: note_id) && Note.find(note_id).manager_id == user.id
         display_order = Note.find(note_id).snippets.size + 1
-        Snippet.create(manager_id: user.id, category: category, description: '', source_type: 'web', source_id: source_id, note_id: note_id, display_order: display_order)
+        Snippet.transaction do
+          snippet = Snippet.create!(manager_id: user.id, category: category, description: '', source_type: 'web', source_id: source_id, note_id: note_id)
+          NoteIndex.create!(snippet_id: snippet.id, note_id: note_id, display_order: display_order)
+        end
       else
         Snippet.create(manager_id: user.id, category: category, description: '', source_type: 'web', source_id: source_id)
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -97,44 +97,41 @@ class Course < ApplicationRecord
     notes.to_a.delete_if { |note| !note.open? }
   end
 
-  def hot_sources
-    duration = 28
-    max_size = 5
-
-    notes_by_members = []
-    members.each do |member|
-      # notes = Note.where("status = 'course' and course_id = ? and manager_id = ?", self.id, member.id).select(:id)
-      # notes_by_members.push [member.id, notes.to_a]
-
-      notes = Note.where("category = 'worksheet' and course_id = ? and manager_id = ?", id, member.id)
-      notes.to_a.delete_if { |note| !note.open? }
-      note_ids = []
-      notes.each do |note|
-        note_ids.push note.id
-      end
-      notes_by_members.push [member.id, note_ids]
-    end
-
-    snippets = []
-    notes_by_members.each do |sbm|
-      snippets.push Snippet.where("source_type = 'web' and note_id in (?) and updated_at >= ?", sbm[1], Date.today - duration).select(:source_id).distinct
-    end
-    snippets.flatten!
-
-    snippets_with_count = []
-    snippets.each do |s|
-      count = snippets.select { |snppt| snppt['source_id'] == s['source_id'] }.size
-      snippets_with_count.push [s['source_id'], count]
-    end
-    snippets_with_count.uniq!
-    snippets_with_count.sort! { |p, q| q[1] <=> p[1] }
-
-    hot_sources = []
-    snippets_with_count[0, max_size].each do |swc|
-      hot_sources.push WebSource.find_by(id: swc[0]) if swc[1] > 1
-    end
-    hot_sources
-  end
+  # def hot_sources
+  #   duration = 28
+  #   max_size = 5
+  #
+  #   notes_by_members = []
+  #   members.each do |member|
+  #     notes = Note.where("category = 'worksheet' and course_id = ? and manager_id = ?", id, member.id)
+  #     notes.to_a.delete_if { |note| !note.open? }
+  #     note_ids = []
+  #     notes.each do |note|
+  #       note_ids.push note.id
+  #     end
+  #     notes_by_members.push [member.id, note_ids]
+  #   end
+  #
+  #   snippets = []
+  #   notes_by_members.each do |sbm|
+  #     snippets.push Snippet.where("source_type = 'web' and note_id in (?) and updated_at >= ?", sbm[1], Date.today - duration).select(:source_id).distinct
+  #   end
+  #   snippets.flatten!
+  #
+  #   snippets_with_count = []
+  #   snippets.each do |s|
+  #     count = snippets.select { |snppt| snppt['source_id'] == s['source_id'] }.size
+  #     snippets_with_count.push [s['source_id'], count]
+  #   end
+  #   snippets_with_count.uniq!
+  #   snippets_with_count.sort! { |p, q| q[1] <=> p[1] }
+  #
+  #   hot_sources = []
+  #   snippets_with_count[0, max_size].each do |swc|
+  #     hot_sources.push WebSource.find_by(id: swc[0]) if swc[1] > 1
+  #   end
+  #   hot_sources
+  # end
 
   def learner_worksheets(user_id, course_staff)
     notes = []

--- a/app/models/course_member.rb
+++ b/app/models/course_member.rb
@@ -61,7 +61,7 @@ class CourseMember < ApplicationRecord
       end
     end
     return true
-  rescue => e
+  rescue StandardError
     logger.info(e.inspect)
     return false
   end

--- a/app/models/note_index.rb
+++ b/app/models/note_index.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: note_indices
+#
+#  id            :integer          not null, primary key
+#  note_id       :integer
+#  snippet_id    :integer
+#  display_order :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+class NoteIndex < ApplicationRecord
+  belongs_to :note, touch: true
+  belongs_to :snippet
+  validates_presence_of :display_order
+  validates_presence_of :note_id
+  validates_presence_of :snippet_id
+  validates_uniqueness_of :display_order, scope: [:note_id]
+  validates_uniqueness_of :snippet_id, scope: [:note_id]
+end

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -2,35 +2,33 @@
 #
 # Table name: snippets
 #
-#  id            :integer          not null, primary key
-#  manager_id    :integer
-#  note_id       :integer
-#  category      :string           default("text")
-#  description   :text
-#  source_type   :string           default("direct")
-#  source_id     :integer
-#  display_order :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id          :integer          not null, primary key
+#  manager_id  :integer
+#  category    :string           default("text")
+#  description :text
+#  source_type :string           default("direct")
+#  source_id   :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 
 class Snippet < ApplicationRecord
   belongs_to :manager, class_name: 'User'
-  belongs_to :note, touch: true
   belongs_to :source, class_name: 'WebSource'
-  has_one :snippet_file
+  has_one :snippet_file, dependent: :destroy
+  has_many :notes, through: :note_indices
+  has_many :note_indices, dependent: :destroy
+  validates_presence_of :description, if: "source_type == 'direct'"
   validates_presence_of :manager_id
   validates_inclusion_of :category, in: %w[text header subheader], if: "source_type == 'direct'"
   validates_inclusion_of :category, in: %w[image pdf], if: "source_type == 'upload'"
   validates_inclusion_of :category, in: %w[text image pdf scratch ted youtube], if: "source_type == 'web'"
   validates_inclusion_of :source_type, in: %w[direct upload web]
   validates_format_of :description, with: /\.(gif|jpe?g|png)/i, message: 'must have an image extension', if: "source_type == 'web' && category == 'image'"
-  after_destroy :cleanup
 
   # ====================================================================
   # Public Functions
   # ====================================================================
-
   def self.headers(snippets)
     headers = []
     snippets.each do |snippet|
@@ -39,20 +37,22 @@ class Snippet < ApplicationRecord
     headers
   end
 
-  def self.with_source_by(manager_id)
-    Snippet.where(manager_id: manager_id, source_type: 'web').to_a
-  end
-
-  def self.with_source_and_without_note_by(manager_id)
-    Snippet.where(manager_id: manager_id, source_type: 'web').where(note_id: nil).order(created_at: :desc).to_a
+  def self.web_snippets_without_note_by(manager_id)
+    snippets = where(manager_id: manager_id, source_type: 'web').order(created_at: :desc).to_a
+    snippets.delete_if { |s| s.note_indices.count > 0 }
   end
 
   def deletable?(user_id)
     (manager_id == user_id)
   end
 
-  def reference_num
-    return '' unless note_id
+  def display_order_for(note_id = nil)
+    return nil unless note_id
+    note_index = NoteIndex.find_by(snippet_id: id, note_id: note_id)
+    note_index ? note_index.display_order : nil
+  end
+
+  def reference_num(note_id)
     note = Note.find(note_id)
     if note
       note.reference_ids.each_with_index do |id, i|
@@ -86,14 +86,23 @@ class Snippet < ApplicationRecord
     description
   end
 
-  # ====================================================================
-  # Private Functions
-  # ====================================================================
-
-  private
-
-  def cleanup
-    return unless (source_type == 'upload') && (category == 'image')
-    snippet_file.destroy if snippet_file
+  def transferable?(user_id, to_note_id = nil)
+    manager = manager_id == user_id
+    # snippets in worksheet with the operation by course learner
+    return false unless manager
+    # snippets in worksheet with the operation by worksheet manager
+    return false if note_indices.size > 1
+    case note_indices.size
+    when 1
+      # snippet manager: from note to nil
+      return true unless to_note_id
+      # snippet manager: from note to note
+      return note_indices[0].note_id != to_note_id
+    when 0
+      # snippet manager: from nil to nil
+      return false unless to_note_id
+      # snippet manager: from nil to note
+      Note.find_by(id: to_note_id).manager_id == user_id
+    end
   end
 end

--- a/app/models/web_source.rb
+++ b/app/models/web_source.rb
@@ -49,17 +49,4 @@ class WebSource < ApplicationRecord
       Regexp.last_match(5)
     end
   end
-
-  def hot_quoting_notes(course_id)
-    duration = 7
-    max_size = 3
-
-    notes = []
-    snippets.each do |snippet|
-      notes.push snippet.note_id if snippet.updated_at >= Date.today - duration
-    end
-    notes.uniq!
-
-    Note.where("status = 'course' and course_id = ? and id in (?)", course_id, notes).order(stars_count: :desc).limit(max_size)
-  end
 end

--- a/app/views/courses/_index.html.erb
+++ b/app/views/courses/_index.html.erb
@@ -41,16 +41,16 @@
 
       <!-- Hot Web Sources -->
       <!-- <div id="hot_sources">
-      <%# hot_sources = @course.hot_sources %>
-      <%#= render(partial: 'notes/hot_sources', locals: {sources: hot_sources, course_id: @course.id}) %>
-    </div> -->
+        <%# hot_sources = @course.hot_sources %>
+        <%#= render(partial: 'notes/hot_sources', locals: {sources: hot_sources, course_id: @course.id}) %>
+      </div> -->
 
-    <!-- Course Lessons -->
-    <%= render partial: 'lessons_card' %>
+      <!-- Course Lessons -->
+      <%= render partial: 'lessons_card' %>
 
-    <!-- Course Goals & Point Allocation -->
-    <%= render partial: 'goal_card', locals: {goals: @goals} %>
+      <!-- Course Goals & Point Allocation -->
+      <%= render partial: 'goal_card', locals: {goals: @goals} %>
 
+    </div>
   </div>
-</div>
 </div>

--- a/app/views/layouts/_note_header.html.erb
+++ b/app/views/layouts/_note_header.html.erb
@@ -32,7 +32,7 @@
       <i class='fa fa-font fa-lg'></i><%= @note.snippets_char_count('all') %> <%= t('.characters') %><span title="<%= t('.written_char_count') %>">（<i class='fa fa-user fa-lg'></i><%= @note.snippets_char_count('direct') %> <%= t('.characters') %>）</span>
     </div>
     <div class="align-left" title="<%= t('.media_count') %>">
-      <i class='fa fa-picture-o fa-lg'></i><%= @note.snippets_count "media" %> <%= t('.pieces') %><span title="<%= t('.uploaded_media_count') %>">（<i class='fa fa-user fa-lg'></i><%= @note.snippets_count "direct_media" %> <%= t('.pieces') %>）</span>
+      <i class='fa fa-picture-o fa-lg'></i><%= @note.snippets_media_count "all" %> <%= t('.pieces') %><span title="<%= t('.uploaded_media_count') %>">（<i class='fa fa-user fa-lg'></i><%= @note.snippets_media_count "upload" %> <%= t('.pieces') %>）</span>
     </div>
     <div class="align-left" title="<%= t('.referenced_web_count') %>">
       <i class='fa fa-globe fa-lg'></i><%= @note.reference_ids.size %> <%= t('.pages') %>

--- a/app/views/layouts/_snippet.html.erb
+++ b/app/views/layouts/_snippet.html.erb
@@ -4,11 +4,11 @@
   </div>
   <% if editable_snippet %>
   <% case snippet.source_type when 'direct' %>
-  <%= render(partial: 'snippets/edit', locals: {snippet: snippet, display_order: snippet.display_order, note_id: @note.id}) %>
-  <%= render(partial: 'snippets/create_snippet_btns', locals: {display_order: snippet.display_order, note_id: @note.id}) %>
+  <%= render(partial: 'snippets/edit', locals: {snippet: snippet, display_order: snippet.display_order_for(@note.id), note_id: @note.id}) %>
+  <%= render(partial: 'snippets/create_snippet_btns', locals: {display_order: snippet.display_order_for(@note.id), note_id: @note.id}) %>
   <% when 'upload' %>
-  <%= render(partial: 'snippets/edit_file', locals: {snippet: snippet, display_order: snippet.display_order, note_id: @note.id}) %>
-  <%= render(partial: 'snippets/create_snippet_btns', locals: {display_order: snippet.display_order, note_id: @note.id}) %>
+  <%= render(partial: 'snippets/edit_file', locals: {snippet: snippet, display_order: snippet.display_order_for(@note.id), note_id: @note.id}) %>
+  <%= render(partial: 'snippets/create_snippet_btns', locals: {display_order: snippet.display_order_for(@note.id), note_id: @note.id}) %>
   <% when 'web' %>
   <%= render(partial: 'snippets/edit_pdf', locals: {snippet: snippet}) if snippet.category == 'pdf' %>
   <% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -92,8 +92,8 @@
 $(function () {
   $('#note_title').focus();
   $('#overview-form').bind('keydown keyup change',function () {
-    charCount("overview-row", $(this).val().length, 500);
+    charCount("overview-row", $(this).val().length, <%= NOTE_OVERVIEW_MAX_LENGTH %>);
   });
-  charCount("overview-row", $('#overview-form').val().length, 500);
+  charCount("overview-row", $('#overview-form').val().length, <%= NOTE_OVERVIEW_MAX_LENGTH %>);
 });
 </script>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -40,7 +40,7 @@
       <i class='fa fa-font fa-lg'></i><%= note.snippets_char_count 'all' %>
     </div>
     <div class="align-left" title="<%= t('.media_count') %>">
-      <i class='fa fa-picture-o fa-lg'></i><%= note.snippets_count 'media' %>
+      <i class='fa fa-picture-o fa-lg'></i><%= note.snippets_media_count 'all' %>
     </div>
     <% if note.stickies.size > 0 %>
     <% title = (current_user && @course)? note_snippet_text(@course.manager?(session[:id]), note.stickies) : t('.sticky_count') %>

--- a/app/views/notes/_source.html.erb
+++ b/app/views/notes/_source.html.erb
@@ -1,12 +1,3 @@
 <div class="source-card card">
   <h3><%= link_to(get_short_string(source.title, 20), source.url, { target: '_blank'}) %></h3>
-  <% notes = source.hot_quoting_notes course_id %>
-  <% if notes.size > 0 %>
-  <span class="badge badge-secondary">参照ノート</span>
-  <ul class="fa-ul">
-    <% notes.each do |note| %>
-    <li><%= link_to((raw("<i class='fa-li fa fa-file-text-o fa-lg'></i>" + get_short_string(note.title, 23))), {controller: 'notes', action: 'ajax_show_from_others', nav_id: course_id, id: note.id}, {remote: true}) %></li>
-    <% end %>
-  </ul>
-  <% end %>
 </div>

--- a/app/views/snippets/_edit_pdf.html.erb
+++ b/app/views/snippets/_edit_pdf.html.erb
@@ -1,6 +1,7 @@
 <% form_id = 'update-pdf-form-' + snippet.id.to_s %>
 <div id="<%= form_id %>" class="to-be-hidden">
-  <%= form_for snippet, url: {action: :ajax_update_pdf, id: snippet.id}, html: {id: 'snippet-form', class: 'form-horizontal', name: 'snippet-form', multipart: true}, remote: true do |f| %>
+  <% url_hash = @note ? {action: :ajax_update_pdf, id: snippet.id, note_id: @note.id} : {action: :ajax_update_pdf, id: snippet.id} %>
+  <%= form_for snippet, url: url_hash, html: {id: 'snippet-form', class: 'form-horizontal', name: 'snippet-form', multipart: true}, remote: true do |f| %>
   <%= render partial: 'snippets/form', locals: {snippet: snippet, f: f, form_id: form_id, category: snippet.category} %>
   <% end %>
 </div>

--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -18,7 +18,7 @@
   </span>
   <% if (defined? snippet) && snippet.category != 'pdf' %>
   <span style="margin-left: 5rem;">
-    <%= render partial: 'layouts/buttons/delete', locals: {action_hash: {action: 'ajax_destroy', id: snippet.id}, id_attr: ''} %>
+    <%= render partial: 'layouts/buttons/delete', locals: {action_hash: {action: 'ajax_destroy', id: snippet.id, note_id: @note.id}, id_attr: ''} %>
   </span>
   <% end %>
 </div>

--- a/app/views/snippets/_index.html.erb
+++ b/app/views/snippets/_index.html.erb
@@ -1,6 +1,7 @@
 <div id="snippet-resource" class="scroll-pane">
   <div class="row">
     <div class="col-md-12">
+      <%= render partial: 'layouts/system_message', locals: {message: flash[:message], message_category: flash[:message_category]} %>
       <div class="clearfix">
         <% if @notes.size.zero? %>
         <%= render partial: 'layouts/system_message', locals: {message: t('.no_note_resources'), message_category: 'info'} %>
@@ -9,7 +10,7 @@
         <% end %>
       </div>
       <% if @snippets.size > 0 %>
-      <%= render partial: 'layouts/system_message', locals: {message: raw("収集した情報はドラッグ＆ドロップ、またはメニュー<i class='fa fa-chevron-circle-down fa-lg'></i>内の操作でノートに貼り付けてください。"), message_category: 'info'} %>
+      <%= render partial: 'layouts/system_message', locals: {message: t('.snippet_transfer'), message_category: 'info'} %>
       <% else %>
       <% if @notes.size > 0 %>
       <%= render partial: 'layouts/system_message', locals: {message: t('.no_snippets'), message_category: 'info'} %>
@@ -35,10 +36,10 @@ $(function () {
     hoverClass: "drop-hover",
     tolerance: "pointer",
     drop: function (e, ui) {
-      var snippet_id = ui.draggable.attr('id').substr(8);
-      var note_id = $(this).attr('id').substr(6);
+      var snippet_id = ui.draggable.attr('id').substr('snippet_'.length);
+      var note_id = $(this).attr('id').substr('note_'.length);
       $.ajax({
-        url:'<%= Rails.application.config.relative_url_root %>/snippets/ajax_paste/'+snippet_id+'?note_id='+note_id
+        url:'<%= Rails.application.config.relative_url_root %>/snippets/ajax_transfer/'+snippet_id+'?to_note_id='+note_id
       })
       ui.draggable.hide();
     }

--- a/app/views/snippets/_snippets.html.erb
+++ b/app/views/snippets/_snippets.html.erb
@@ -1,4 +1,5 @@
 <div id="snippets" style="overflow: auto;">
+  <%= render partial: 'layouts/system_message', locals: {message: flash[:message], message_category: flash[:message_category]} %>
   <%= render partial: 'layouts/snippet', collection: @snippets, locals: {editable_snippet: true} %>
 </div>
 

--- a/app/views/snippets/items/_footer.html.erb
+++ b/app/views/snippets/items/_footer.html.erb
@@ -2,7 +2,8 @@
   <div class="card-footer">
     <div class="d-flex justify-content-between">
       <div>
-        <%= link_to(get_short_string(snippet.reference_num + ' ' + display_title(snippet.source), 25), snippet.source.url, {target: '_blank'}) %>
+        <% link_title = @note ? snippet.reference_num(@note.id) + ' ' + display_title(snippet.source) : display_title(snippet.source) %>
+        <%= link_to(get_short_string(link_title, 25), snippet.source.url, {target: '_blank'}) %>
       </div>
 
       <% if controller_name == 'snippets' %>

--- a/app/views/snippets/items/_operations_direct.html.erb
+++ b/app/views/snippets/items/_operations_direct.html.erb
@@ -1,3 +1,3 @@
 <div class="operation-direct">
-  <a id="update-snippet-btn-<%= snippet.display_order %>" style="cursor:pointer;"><i class='fa fa-pencil fa-lg' title="<%= t('.edit') %>"></i></a>
+  <a id="update-snippet-btn-<%= snippet.display_order_for @note.id %>" style="cursor:pointer;"><i class='fa fa-pencil fa-lg' title="<%= t('.edit') %>"></i></a>
 </div>

--- a/app/views/snippets/items/_operations_upload.html.erb
+++ b/app/views/snippets/items/_operations_upload.html.erb
@@ -1,4 +1,4 @@
 <div class="operation-direct">
-  <%= link_to(raw("<i class='fa fa-trash-o fa-lg'></i>"), {action: 'ajax_destroy', id: snippet.id}, {title: t('.delete'), remote: true}) %>
-  <a id="update-snippet-btn-<%= snippet.display_order %>" style="cursor:pointer;"><i class='fa fa-upload fa-lg' title="<%= t('.edit') %>"></i></a>
+  <%= link_to(raw("<i class='fa fa-trash-o fa-lg'></i>"), {action: 'ajax_destroy', id: snippet.id, note_id: @note.id}, {title: t('.delete'), remote: true}) %>
+  <a id="update-snippet-btn-<%= snippet.display_order_for @note.id %>" style="cursor:pointer;"><i class='fa fa-upload fa-lg' title="<%= t('.edit') %>"></i></a>
 </div>

--- a/app/views/snippets/items/_operations_web.html.erb
+++ b/app/views/snippets/items/_operations_web.html.erb
@@ -1,16 +1,19 @@
 <div id="snippet-<%= snippet.id %>-operations" class="collapse operation-list">
-  <div class="operation-header">切り抜き日時：<%= l(snippet.created_at, format: :default) %></div>
+  <div class="operation-header"><%= t('.cited_date') %> : <%= l(snippet.created_at.to_date, format: :default) %></div>
   <ul class="fa-ul">
     <% if snippet.category == 'pdf' %>
-    <li><a id="update-pdf-snippet-btn-<%= snippet.id %>" style="cursor:pointer;"><i class='fa fa-li fa-pencil'></i> PDFファイルの引用文を入力</a></li>
+    <li><a id="update-pdf-snippet-btn-<%= snippet.id %>" style="cursor:pointer;"><i class='fa fa-li fa-pencil'></i> <%= t('.enter_citation') %></a></li>
     <% end %>
     <% @notes.each do |note| %>
-    <% next if snippet.note_id && (snippet.note_id == note.id) %>
-    <li><%= link_to(raw("<i class='fa-li fa fa-file-text-o'></i>「#{note.title}」に貼り付け"), {action: 'ajax_paste', id: snippet.id, note_id: note.id}, {remote: true}) %></li>
+    <% if snippet.transferable? session[:id], note.id %>
+    <% link_hash = @note ? {action: 'ajax_transfer', id: snippet.id, to_note_id: note.id, from_note_id: @note.id} : {action: 'ajax_transfer', id: snippet.id, to_note_id: note.id} %>
+    <li><%= link_to(raw("<i class='fa-li fa fa-file-text-o'></i>") + t('.transfer_to', note_title: note.title), link_hash, {remote: true}) %></li>
     <% end %>
-    <% if snippet.note_id %>
-    <li><%= link_to(raw("<i class='fa-li fa fa-file-text'></i> ノートからはがす"), {action: 'ajax_paste', id: snippet.id}, {remote: true}) %></li>
     <% end %>
-    <li><%= link_to(raw("<i class='fa-li fa fa-trash-o'></i>") + t('.delete'), {action: 'ajax_destroy', id: snippet.id}, {remote: true}) %></li>
+    <% if snippet.transferable? session[:id] %>
+    <li><%= link_to(raw("<i class='fa-li fa fa-file-text'></i>") + t('.remove'), {action: 'ajax_transfer', id: snippet.id, from_note_id: @note.id}, {remote: true}) %></li>
+    <% end %>
+    <% link_hash = @note ? {action: 'ajax_destroy', id: snippet.id, note_id: @note.id} : {action: 'ajax_destroy', id: snippet.id} %>
+    <li><%= link_to(raw("<i class='fa-li fa fa-trash-o'></i>") + t('.delete'), link_hash, {remote: true}) %></li>
   </ul>
 </div>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -51,6 +51,9 @@ COURSE_SEARCH_MAX_SIZE = 50
 # initial setting for lesson status: draft / open
 LESSON_STATUS_DEFAULT = 'open'.freeze
 
+# max character length for note overview
+NOTE_OVERVIEW_MAX_LENGTH = 500
+
 # max peer review number per learner
 NOTE_PEER_REVIEW_MAX_SIZE = 9
 

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -9,3 +9,6 @@ en:
       setup_error2: As the admin account has already been registered, you can not register again.
     snippets:
       note_creation_error: Creating note failed. Please check the input values.
+      note_transfer_error: Transferring note failed
+      snippet_creation_error: Failed to save text
+      snippet_upload_error: Failed to save file

--- a/config/locales/controllers/ja.yml
+++ b/config/locales/controllers/ja.yml
@@ -9,3 +9,6 @@ ja:
       setup_error2: 既に最高管理者アカウントが登録されているため、再度、登録することはできません
     snippets:
       note_creation_error: ノートの作成に失敗しました。入力した値を確認して下さい。
+      note_transfer_error: ノートの移動に失敗しました
+      snippet_creation_error: テキストの保存に失敗しました
+      snippet_upload_error: ファイルの保存に失敗しました

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -229,6 +229,7 @@ en:
     index:
       no_note_resources: Currently no notes managed
       no_snippets: Currently no snippets
+      snippet_transfer: Please transfer the citation to the note by drag and drop or select the item in "Operation"
     items:
       footer:
         operations: Operations
@@ -240,7 +241,11 @@ en:
         delete: :layouts.buttons.delete.delete
         edit: :layouts.buttons.edit.edit
       operations_web:
+        cited_date: Cited date
         delete: :layouts.buttons.delete.delete
+        enter_citation: Enter citation text from PDF file
+        remove: Remove from this note
+        transfer_to: 'Transfer to "%{note_title}"'
     toolbar:
       export: Export to text
       preferences: :helpers.preferences

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -229,6 +229,7 @@ ja:
     index:
       no_note_resources: 現在、管理しているノートはありません
       no_snippets: 現在、ノートに未保存のWebから収集した情報はありません
+      snippet_transfer: 引用した情報はドラッグ＆ドロップ、またはメニュー「操作」からノートに移動して下さい
     items:
       footer:
         operations: 操作
@@ -240,7 +241,11 @@ ja:
         delete: :layouts.buttons.delete.delete
         edit: :layouts.buttons.edit.edit
       operations_web:
+        cited_date: 引用日
         delete: :layouts.buttons.delete.delete
+        enter_citation: PDFファイルからの引用文を入力
+        remove: このノートからはがす
+        transfer_to: '「%{note_title}」に移動'
     toolbar:
       export: 文章を出力
       preferences: :helpers.preferences

--- a/db/migrate/20171001071614_create_note_indices.rb
+++ b/db/migrate/20171001071614_create_note_indices.rb
@@ -1,0 +1,13 @@
+class CreateNoteIndices < ActiveRecord::Migration[5.0]
+  def change
+    create_table :note_indices do |t|
+      t.integer :note_id
+      t.integer :snippet_id
+      t.integer :display_order
+
+      t.timestamps
+    end
+    add_index :note_indices, :note_id
+    add_index :note_indices, %i[snippet_id note_id], unique: true
+  end
+end

--- a/db/migrate/20171002064226_remove_note_id_from_snippets.rb
+++ b/db/migrate/20171002064226_remove_note_id_from_snippets.rb
@@ -1,0 +1,10 @@
+class RemoveNoteIdFromSnippets < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :snippets, :note_id
+  end
+
+  def down
+    add_column :snippets, :note_id, :integer
+    add_index :snippets, :note_id
+  end
+end

--- a/db/migrate/20171002064239_remove_display_order_from_snippets.rb
+++ b/db/migrate/20171002064239_remove_display_order_from_snippets.rb
@@ -1,0 +1,9 @@
+class RemoveDisplayOrderFromSnippets < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :snippets, :display_order
+  end
+
+  def down
+    add_column :snippets, :display_order, :integer
+  end
+end

--- a/test/factories/note_indices.rb
+++ b/test/factories/note_indices.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: note_indices
+#
+#  id            :integer          not null, primary key
+#  note_id       :integer
+#  snippet_id    :integer
+#  display_order :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :note_index do
+    association :note
+    association :snippet
+    sequence(:display_order) { |i| i }
+  end
+end

--- a/test/factories/snippets.rb
+++ b/test/factories/snippets.rb
@@ -2,25 +2,21 @@
 #
 # Table name: snippets
 #
-#  id            :integer          not null, primary key
-#  manager_id    :integer
-#  note_id       :integer
-#  category      :string           default("text")
-#  description   :text
-#  source_type   :string           default("direct")
-#  source_id     :integer
-#  display_order :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id          :integer          not null, primary key
+#  manager_id  :integer
+#  category    :string           default("text")
+#  description :text
+#  source_type :string           default("direct")
+#  source_id   :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 
 FactoryGirl.define do
   factory :snippet do
     association :manager, factory: :user
-    association :note
     association :source, factory: :web_source
     description 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '
-    sequence(:display_order) { |i| i }
 
     factory :header_snippet do
       category 'header'

--- a/test/models/note_index_test.rb
+++ b/test/models/note_index_test.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: note_indices
+#
+#  id            :integer          not null, primary key
+#  note_id       :integer
+#  snippet_id    :integer
+#  display_order :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+require 'test_helper'
+
+class NoteIndexTest < ActiveSupport::TestCase
+  # ====================================================================
+  # Validation Tests
+  # ====================================================================
+  # test for valid note_index data
+  test 'a note_index with valid data is valid' do
+    assert build(:note_index).valid?
+  end
+
+  # test for validates_presence_of :display_order
+  test 'a note_index without display_order is invalid' do
+    assert_invalid build(:note_index, display_order: ''), :display_order
+    assert_invalid build(:note_index, display_order: nil), :display_order
+  end
+
+  # test for validates_presence_of :note_id
+  test 'a note_index without note_id is invalid' do
+    assert_invalid build(:note_index, note_id: ''), :note_id
+    assert_invalid build(:note_index, note_id: nil), :note_id
+  end
+
+  # test for validates_presence_of :snippet_id
+  test 'a note_index without snippet_id is invalid' do
+    assert_invalid build(:note_index, snippet_id: ''), :snippet_id
+    assert_invalid build(:note_index, snippet_id: nil), :snippet_id
+  end
+
+  # test for validates_uniqueness_of :display_order, scope: [:note_id]
+  test 'some note_indices with same display_order and note_id are invalid' do
+    note_index = create(:note_index)
+    assert_invalid build(:note_index, display_order: note_index.display_order, note_id: note_index.note_id), :display_order
+  end
+
+  # test for validates_uniqueness_of :snippet_id, scope: [:note_id]
+  test 'some note_indices with same snippet_id and note_id are invalid' do
+    note_index = create(:note_index)
+    assert_invalid build(:note_index, snippet_id: note_index.snippet_id, note_id: note_index.note_id), :snippet_id
+  end
+end

--- a/test/models/snippet_test.rb
+++ b/test/models/snippet_test.rb
@@ -2,16 +2,14 @@
 #
 # Table name: snippets
 #
-#  id            :integer          not null, primary key
-#  manager_id    :integer
-#  note_id       :integer
-#  category      :string           default("text")
-#  description   :text
-#  source_type   :string           default("direct")
-#  source_id     :integer
-#  display_order :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id          :integer          not null, primary key
+#  manager_id  :integer
+#  category    :string           default("text")
+#  description :text
+#  source_type :string           default("direct")
+#  source_id   :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 
 require 'test_helper'
@@ -33,6 +31,12 @@ class SnippetTest < ActiveSupport::TestCase
     assert build(:web_scratch_snippet).valid?
     assert build(:web_ted_snippet).valid?
     assert build(:web_youtube_snippet).valid?
+  end
+
+  # test for validates_presence_of :description, if: "source_type == 'direct'"
+  test 'a snippet without description is invalid' do
+    assert_invalid build(:snippet, description: ''), :description
+    assert_invalid build(:snippet, description: nil), :description
   end
 
   # test for validates_presence_of :manager_id


### PR DESCRIPTION
In order to avoid duplicating snippets by the number of learners
when creating each learners' worksheet from original worksheet.