### PR TITLE
:fire: Remove course sticky shortcut key

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -24,7 +24,9 @@ $(document).ajaxSend(function (e, xhr, options) {
 function keyBinder(target_doc) {
   // target_doc may be document or iframe's document
   var binding_keys = ["left", "j", "shift+left", "shift+j", "right", "k", "shift+right", "shift+k", "shift+up", "shift+down"]; // page move
-  binding_keys = binding_keys.concat(["l", "shift+l"]); // sticky form
+  // FIXME: Redesign sticky-bar
+  // binding_keys = binding_keys.concat(["l", "shift+l"]); // sticky form
+  binding_keys = binding_keys.concat(["l"]); // sticky form
   binding_keys = binding_keys.concat(["f"]); // sub-pane toggle
   binding_keys = binding_keys.concat(["/", "shift+/"]); // message-card toggle
   jQuery.each(binding_keys, function (i, binding_key) {
@@ -33,9 +35,10 @@ function keyBinder(target_doc) {
         case "l":
         toggleCreateSticky("private");
         break;
-        case "shift+l":
-        toggleCreateSticky("course");
-        break;
+        // FIXME: Redesign sticky-bar
+        // case "shift+l":
+        // toggleCreateSticky("course");
+        // break;
         case "f":
         $("#wrapper").toggleClass("toggled");
         break;

--- a/app/views/contents/_index.html.erb
+++ b/app/views/contents/_index.html.erb
@@ -28,17 +28,18 @@
           </p>
           【ページ操作】
           <ul>
-            <li>次のページに移動： → または k</li>
             <li>前のページに移動： ← または j</li>
-            <li>5ページ先に移動： Shift + → または Shift + k</li>
+            <li>次のページに移動： → または k</li>
             <li>5ページ前に移動： Shift + ← または Shift + j</li>
+            <li>5ページ先に移動： Shift + → または Shift + k</li>
             <li>表紙ページに移動： Shift + ↑</li>
             <li>課題ページに移動： Shift + ↓</li>
           </ul>
           【ふせん操作】
           <ul>
             <li>個人ふせんを作成： l（エル）</li>
-            <li>コースふせんを作成： Shift + l</li>
+            <!-- FIXME: Redesign sticky-bar -->
+            <!-- <li>コースふせんを作成： Shift + l</li> -->
             <li>編集中のふせんを貼る： Shift + Enter</li>
             <li>編集中のふせんをキャンセル： Esc</li>
           </ul>

--- a/app/views/layouts/_message_card.html.erb
+++ b/app/views/layouts/_message_card.html.erb
@@ -6,20 +6,20 @@
       <td class="key"></td>
     </tr>
     <tr>
-      <td class="action">　・次のページに移動</td>
-      <td class="key">→ または k</td>
-    </tr>
-    <tr>
       <td class="action">　・前のページに移動</td>
       <td class="key">← または j</td>
     </tr>
     <tr>
-      <td class="action">　・5ページ先に移動</td>
-      <td class="key">Shift + → または Shift + k</td>
+      <td class="action">　・次のページに移動</td>
+      <td class="key">→ または k</td>
     </tr>
     <tr>
       <td class="action">　・5ページ前に移動</td>
       <td class="key">Shift + ← または Shift + j</td>
+    </tr>
+    <tr>
+      <td class="action">　・5ページ先に移動</td>
+      <td class="key">Shift + → または Shift + k</td>
     </tr>
     <tr>
       <td class="action">　・表紙ページに移動</td>
@@ -37,10 +37,11 @@
       <td class="action">　・個人ふせんを作成</td>
       <td class="key">l（エル）</td>
     </tr>
-    <tr>
+    <!-- FIXME: Redesign sticky-bar -->
+    <!-- <tr>
       <td class="action">　・コースふせんを作成</td>
       <td class="key">Shift + l</td>
-    </tr>
+    </tr> -->
     <tr>
       <td class="action">　・編集中のふせんを貼る</td>
       <td class="key">Shift + Enter</td>


### PR DESCRIPTION
Experimentally delete shortcut key for course sticky.
In the near future, along with the introduction of default notes for course,
reconsider the shortcut key again.