### PR TITLE
:sparkles: Correspond to content page with PDF file #84

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'sass-rails', '~> 5.0.6'
 # gem 'therubyracer', platforms: :ruby
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '~> 3.2.0'
+gem 'combine_pdf'
+gem 'pdfjs_viewer-rails'
 
 group :development, :test do
   gem 'sqlite3', '~> 1.3.0'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -213,6 +213,8 @@ class ApplicationController < ActionController::Base
         else
           return 'iframe/video_page/' + file.id.to_s
         end
+      when 'a' then
+        return content_type_pdf?(file.upload_content_type) ? '/pdfjs/minimal?file=' + file.upload.url : 'iframe/object_page/' + file.id.to_s
       end
     end
   end
@@ -386,5 +388,10 @@ class ApplicationController < ActionController::Base
     when max_page_num
       -1
     end
+  end
+
+  def content_type_pdf?(type)
+    types = type.split('/')
+    types.nil? || types.length < 2 ? false : types[1].include?('pdf')
   end
 end

--- a/app/controllers/iframe_controller.rb
+++ b/app/controllers/iframe_controller.rb
@@ -10,4 +10,8 @@ class IframeController < ApplicationController
   def video_page
     @page_file = PageFile.find(params[:id].to_i)
   end
+
+  def object_page
+    @page_file = PageFile.find(params[:id].to_i)
+  end
 end

--- a/app/views/iframe/object_page.html.erb
+++ b/app/views/iframe/object_page.html.erb
@@ -1,0 +1,1 @@
+<object data="<%= h @page_file.upload.url %>" type="<%= h @page_file.upload_content_type %>" style-"width: 100%; height: 100%"></iframe>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   root 'signin#index'
   match ':controller(/:action(/:id(.:format)))', via: [:get, :post, :put, :patch]
 
+  mount PdfjsViewer::Rails::Engine => "/pdfjs", as: 'pdfjs'
+
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 


### PR DESCRIPTION
- Enable to upload a pdf file as a page file.
- Save the uploaded multi-page pdf file into the separate single page PDF fil$
- Rendering PDF using the HTML5 Canvas.
For this , use 2 new gem, 'combine_pdf' and 'pdfjs_viewer-rails'.